### PR TITLE
Bug when most active user is "Local"

### DIFF
--- a/data/interfaces/default/home_stats.html
+++ b/data/interfaces/default/home_stats.html
@@ -113,9 +113,14 @@ DOCUMENTATION :: END
 
                 <div class="home-platforms-instance-name">
                     <h4>Most Active User</h4>
+                    % if a['rows'][0]['user_id']:
                     <a href="user?user_id=${a['rows'][0]['user_id']}">
                         <h5>${a['rows'][0]['friendly_name']}</h5>
                     </a>
+                    % else:
+                    <a href="user?user=${a['rows'][0]['friendly_name']}">
+                        <h5>${a['rows'][0]['friendly_name']}</h5>
+                    % endif
                 </div>
                 <div class="user-platforms-instance-playcount">
                     <h3>${a['rows'][0]['total_plays']}</h3>


### PR DESCRIPTION
When the most active user is a "Local" user i.e. user who uses Plex without signing in(accessing in local networks mostly DLNA), then a['rows'][0]['user_id'] is set to None. This fixes it.
