### PR TITLE
Allow a user to change home page statistics day length

### DIFF
--- a/data/interfaces/default/graphs.html
+++ b/data/interfaces/default/graphs.html
@@ -21,6 +21,9 @@
                 </label>
             </div>
             <div class="btn-group" data-toggle="buttons" id="days-selection">
+                <label class="btn btn-dark">
+                    <input type="radio" name="date-options" id="graph-7" value="7" autocomplete="off"> 7 days
+                </label>
                 <label class="btn btn-dark active">
                     <input type="radio" name="date-options" id="graph-30" value="30" autocomplete="off" checked> 30 days
                 </label>

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -19,7 +19,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="padded-header">
-                <h3>Statistics <small>Last 30 days</small></h3>
+                <h3>Statistics <small>Last ${config['home_stats_length']} days</small></h3>
             </div>
             <div id="home-stats" class="user-platforms">
                 <div class='text-muted'><i class="fa fa-refresh fa-spin"></i> Loading stats...</div>
@@ -110,7 +110,7 @@
         });
     });
 
-    getHomeStats(30);
+    getHomeStats(${config['home_stats_length']});
 
 
 </script>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -274,6 +274,16 @@ available_notification_agents = notifiers.available_notification_agents()
                             <p class="help-block">If you have media indexing enabled on your server, use these on the activity pane.</p>
                         </div>
 
+                        <div class="form-group">
+                            <label for="home_stats_length">Homepage Statistics Time Frame</label>
+                            <div class="row">
+                                <div class="col-md-2">
+                                    <input type="text" class="form-control" data-parsley-type="integer" id="home_stats_length" name="home_stats_length" value="${config['home_stats_length']}" size="3" data-parsley-min="0" data-parsley-trigger="change" required>
+                                </div>
+                            </div>
+                            <p class="help-block">Specify the number of days for the statistics on the home page. Default is 30 days.</p>
+                        </div>
+
                         <div class="padded-header">
                             <h3>Plex Logs</h3>
                         </div>

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -71,6 +71,7 @@ _CONFIG_DEFINITIONS = {
     'GROWL_ON_PLAY': (int, 'Growl', 0),
     'GROWL_ON_STOP': (int, 'Growl', 0),
     'GROWL_ON_WATCHED': (int, 'Growl', 0),
+    'HOME_STATS_LENGTH': (int, 'General', 30),
     'HTTPS_CERT': (str, 'General', ''),
     'HTTPS_KEY': (str, 'General', ''),
     'HTTP_HOST': (str, 'General', '0.0.0.0'),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -64,7 +64,10 @@ class WebInterface(object):
 
     @cherrypy.expose
     def home(self):
-        return serve_template(templatename="index.html", title="Home")
+        config = {
+            "home_stats_length": plexpy.CONFIG.HOME_STATS_LENGTH
+        }
+        return serve_template(templatename="index.html", title="Home", config=config)
 
     @cherrypy.expose
     def welcome(self, **kwargs):
@@ -434,7 +437,8 @@ class WebInterface(object):
             "notify_on_stop_subject_text": plexpy.CONFIG.NOTIFY_ON_STOP_SUBJECT_TEXT,
             "notify_on_stop_body_text": plexpy.CONFIG.NOTIFY_ON_STOP_BODY_TEXT,
             "notify_on_watched_subject_text": plexpy.CONFIG.NOTIFY_ON_WATCHED_SUBJECT_TEXT,
-            "notify_on_watched_body_text": plexpy.CONFIG.NOTIFY_ON_WATCHED_BODY_TEXT
+            "notify_on_watched_body_text": plexpy.CONFIG.NOTIFY_ON_WATCHED_BODY_TEXT,
+            "home_stats_length": plexpy.CONFIG.HOME_STATS_LENGTH
         }
 
         return serve_template(templatename="settings.html", title="Settings", config=config)


### PR DESCRIPTION
Should close #14. I added the option in extra settings and used your default of 30 days. Let me know if you would rather it be somewhere else. 

I really like this project. You have done an amazing job! Thanks for all the hard work.
