### PR TITLE
Add group editing of users from the user table

### DIFF
--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -418,6 +418,7 @@ input[type="color"],
     webkit-box-shadow: 0 0 4px rgba(0,0,0,.3),inset 0 0 0 1px rgba(255,255,255,.1);
     -moz-box-shadow: 0 0 4px rgba(0,0,0,.3),inset 0 0 0 1px rgba(255,255,255,.1);
     box-shadow: 0 0 4px rgba(0,0,0,.3),inset 0 0 0 1px rgba(255,255,255,.1);
+    overflow: hidden;
 }
 .cover-face {
     background-position: center;
@@ -826,8 +827,6 @@ input[type="color"],
     -ms-backface-visibility: hidden;
     -o-backface-visibility: hidden;
     backface-visibility: hidden;
-    width: auto;
-    height: 260px;
     border: 1px solid rgba(128, 128, 128, 0.3);
 }
 .summary-content {
@@ -1683,6 +1682,26 @@ input[type="color"],
 }
 .history-title .popover.right .popover-content {
     padding: 5px 8px;
+}
+.edit-user-toggles {
+    padding-right: 10px;
+}
+.edit-user-toggles > input[type='checkbox'] {
+    display: none;
+}
+.edit-user-toggles > input[type='checkbox'] + label {
+    color: #444;
+    cursor: pointer;
+}
+.edit-user-toggles > input[type='checkbox']:checked + label {
+    color: #fff;
+    cursor: pointer;
+}
+.popover .popover-content {
+    color: #000;
+}
+#users-to-delete > li {
+    color: #e9a049;
 }
 #updatebar {
     background-color: #444;

--- a/data/interfaces/default/js/tables/users.js
+++ b/data/interfaces/default/js/tables/users.js
@@ -11,13 +11,28 @@ users_list_table_options = {
     "processing": false,
     "serverSide": true,
     "pageLength": 10,
-    "order": [ 1, 'asc'],
+    "order": [ 2, 'asc'],
     "autoWidth": true,
     "stateSave": true,
     "pagingType": "bootstrap",
     "columnDefs": [
         {
             "targets": [0],
+            "data": null,
+            "createdCell": function (td, cellData, rowData, row, col) {
+                $(td).html('<div class="edit-user-toggles"><button class="btn btn-xs btn-warning" data-id="' + rowData['user_id'] + '" data-toggle="button"><i class="fa fa-eraser fa-fw"></i> Purge</button>&nbsp&nbsp&nbsp' +
+                    '<input type="checkbox" id="do_notify-' + rowData['user_id'] + '" name="do_notify" value="1" ' + rowData['do_notify'] + '><label class="edit-tooltip" for="do_notify-' + rowData['user_id'] + '" data-toggle="tooltip" title="Toggle Notifications"><i class="fa fa-bell fa-lg fa-fw"></i></label>&nbsp' +
+                    '<input type="checkbox" id="keep_history-' + rowData['user_id'] + '" name="keep_history" value="1" ' + rowData['keep_history'] + '><label class="edit-tooltip" for="keep_history-' + rowData['user_id'] + '" data-toggle="tooltip" title="Toggle History"><i class="fa fa-history fa-lg fa-fw"></i></label>&nbsp' +
+                    // Show/hide user currently doesn't work
+                    '<input type="checkbox" id="show_hide-' + rowData['user_id'] + '" name="show_hide" value="1" checked><label class="edit-tooltip" for="show_hide-' + rowData['user_id'] + '" data-toggle="tooltip" title="Show/Hide User"><i class="fa fa-eye fa-lg fa-fw"></i></label>');
+            },
+            "width": "7%",
+            "className": "edit-control no-wrap hidden",
+            "searchable": false,
+            "orderable": false
+        },
+        {
+            "targets": [1],
             "data": "user_thumb",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData === '') {
@@ -32,23 +47,26 @@ users_list_table_options = {
             "className": "users-poster-face"
         },
         {
-            "targets": [1],
+            "targets": [2],
             "data": "friendly_name",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
                     if (rowData['user_id'] > 0) {
-                        $(td).html('<a href="user?user_id=' + rowData['user_id'] + '">' + cellData + '</a>');
+                        $(td).html('<div class="edit-user-name" data-id="' + rowData['user_id'] + '"><a href="user?user_id=' + rowData['user_id'] + '">' + cellData + '</a>' +
+                            '<input type="text" class="hidden" value="' + cellData + '"></div>');
                     } else {
-                        $(td).html('<a href="user?user=' + rowData['user'] + '">' + cellData + '</a>');
+                        $(td).html('<div class="edit-user-name" data-id="' + rowData['user_id'] + '"><a href="user?user=' + rowData['user'] + '">' + cellData + '</a>' +
+                            '<input type="text" class="hidden" value="' + cellData + '"></div>');
                     }
                 } else {
                     $(td).html(cellData);
                 }
             },
-            "width": "15%"
+            "width": "12%",
+            "className": "edit-user-control no-wrap"
         },
         {
-            "targets": [2],
+            "targets": [3],
             "data": "last_seen",
             "render": function ( data, type, full ) {
                 if (data) {
@@ -58,11 +76,11 @@ users_list_table_options = {
                 }
             },
             "searchable": false,
-            "width": "15%",
+            "width": "12%",
             "className": "no-wrap hidden-xs"
         },
         {
-            "targets": [3],
+            "targets": [4],
             "data": "ip_address",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData) {
@@ -79,32 +97,32 @@ users_list_table_options = {
                     $(td).html('n/a');
                 }
             },
-            "width": "15%",
+            "width": "12%",
             "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control-ip"
         },
         {
-            "targets": [4],
+            "targets": [5],
             "data":"platform",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData) {
                     var transcode_dec = '';
                     if (rowData['video_decision'] === 'transcode') {
-                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Transcode"><i class="fa fa-server fa-fw"></i></span>&nbsp';
+                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Transcode"><i class="fa fa-server fa-fw"></i></span>';
                     } else if (rowData['video_decision'] === 'copy') {
-                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Stream"><i class="fa fa-video-camera fa-fw"></i></span>&nbsp';
+                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Stream"><i class="fa fa-video-camera fa-fw"></i></span>';
                     } else if (rowData['video_decision'] === 'direct play' || rowData['video_decision'] === '') {
-                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Play"><i class="fa fa-play-circle fa-fw"></i></span>&nbsp';
+                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Play"><i class="fa fa-play-circle fa-fw"></i></span>';
                     }
                     $(td).html('<div><a href="#" data-target="#info-modal" data-toggle="modal"><div style="float: left;">' + transcode_dec + '&nbsp' + cellData + '</div></a></div>');
                 } else {
                     $(td).html('n/a');
                 }
             },
-            "width": "15%",
+            "width": "12%",
             "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
         },
         {
-            "targets": [5],
+            "targets": [6],
             "data":"last_watched",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -129,14 +147,15 @@ users_list_table_options = {
                     }
                 }
             },
+            "width": "30%",
             "className": "hidden-sm hidden-xs"
         },
         {
-            "targets": [6],
+            "targets": [7],
             "data": "plays",
             "searchable": false,
             "width": "10%"
-            }
+        }
 
     ],
     "drawCallback": function (settings) {
@@ -145,6 +164,8 @@ users_list_table_options = {
         $('#ajaxMsg').fadeOut();
 
         // Create the tooltips.
+        $('.purge-tooltip').tooltip();
+        $('.edit-tooltip').tooltip();
         $('.transcode-tooltip').tooltip();
         $('.media-type-tooltip').tooltip();
         $('.watched-tooltip').tooltip();
@@ -157,6 +178,11 @@ users_list_table_options = {
             }
         });
 
+        if ($('#row-edit-mode').hasClass('active')) {
+            $('.edit-control').each(function () {
+                $(this).removeClass('hidden');
+            });
+        }
     },
     "preDrawCallback": function(settings) {
         var msg = "<div class='msg'><i class='fa fa-refresh fa-spin'></i>&nbspFetching rows...</div>";
@@ -204,4 +230,51 @@ $('#users_list_table').on('click', 'td.modal-control-ip', function () {
     }
 
     getUserLocation(rowData['ip_address']);
+});
+
+$('#users_list_table').on('change', 'td.edit-control > .edit-user-toggles > input, td.edit-user-control > .edit-user-name > input', function () {
+    var tr = $(this).parents('tr');
+    var row = users_list_table.row(tr);
+    var rowData = row.data();
+
+    var do_notify = 0;
+    var keep_history = 0;
+    if ($('#do_notify-' + rowData['user_id']).is(':checked')) {
+        do_notify = 1;
+    }
+    if ($('#keep_history-' + rowData['user_id']).is(':checked')) {
+        keep_history = 1;
+    }
+
+    friendly_name = tr.find('td.edit-user-control > .edit-user-name > input').val();
+
+    $.ajax({
+        url: 'edit_user',
+        data: {
+            user_id: rowData['user_id'],
+            friendly_name: friendly_name,
+            do_notify: do_notify,
+            keep_history: keep_history,
+            thumb: rowData['user_thumb']
+        },
+        cache: false,
+        async: true,
+        success: function (data) {
+            var msg = "User updated";
+            showMsg(msg, false, true, 2000);
+        }
+    });
+});
+
+$('#users_list_table').on('click', 'td.edit-control > .edit-user-toggles > button', function () {
+    var tr = $(this).parents('tr');
+    var row = users_list_table.row(tr);
+    var rowData = row.data();
+
+    //$(this).prop('disabled', true);
+    if ($(this).hasClass('active')) {
+        $(this).toggleClass('btn-warning').toggleClass('btn-danger');
+    } else {
+        $(this).toggleClass('btn-danger').toggleClass('btn-warning');
+    }
 });

--- a/data/interfaces/default/users.html
+++ b/data/interfaces/default/users.html
@@ -12,6 +12,11 @@
             <span><i class="fa fa-group"></i> All Users</span>
         </div>
         <div class="button-bar">
+            <span data-toggle="popover" data-placement="left" data-content="Data purging does not occur until after exiting edit mode." id="purge-message">
+                <button class="btn btn-dark" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
+                    <i class="fa fa-pencil"></i> Edit mode
+                </button>&nbsp
+            </span>
             <button class="btn btn-dark" id="refresh-users-list"><i class="fa fa-refresh"></i> Refresh users</button>
         </div>
     </div>
@@ -19,6 +24,7 @@
         <table id="users_list_table" class="display" width="100%">
             <thead>
             <tr>
+                <th align="left" id="edit_row">Edit</th>
                 <th align="right" id="avatar"></th>
                 <th align="left" id="friendly_name">User</th>
                 <th align="left" id="last_seen">Last Seen</th>
@@ -35,6 +41,25 @@
         </div>
         <div class="modal fade" id="ip-info-modal" tabindex="-1" role="dialog" aria-labelledby="ip-info-modal">
         </div>
+        <div class="modal fade" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-modal">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-remove"></i></button>
+                        <h4 class="modal-title" id="myModalLabel">Confirm Purge</h4>
+                    </div>
+                    <div class="modal-body" style="text-align: center;">
+                        <p>Are you REALLY sure you want to purge all history for the following users:</p>
+                        <ul id="users-to-delete" class="list-unstyled"></ul>
+                        <p>This is permanent and cannot be undone!</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-dark" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" id="confirm-purge">Purge</button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -47,7 +72,7 @@
 <script src="interfaces/default/js/moment-with-locale.js"></script>
 <script src="interfaces/default/js/tables/users.js"></script>
 <script>
-    $(document).ready(function() {
+    $(document).ready(function () {
         users_list_table_options.ajax = {
             "url": "get_user_list",
             type: "post",
@@ -59,8 +84,64 @@
         users_list_table = $('#users_list_table').DataTable(users_list_table_options);
 
         clearSearchButton('users_list_table', users_list_table);
-    });
 
+        var users_to_purge = [];
+        $('#row-edit-mode').on('click', function () {
+            $(this).parents('span#purge-message').popover('toggle');
+
+            if ($(this).hasClass('active')) {
+                users_to_purge = [];
+                ul = $('#users-to-delete');
+                ul.html('');
+                $('.edit-control button.btn-danger').map(function () {
+                    users_to_purge.push($(this).attr('data-id'));
+                    ul.append('<li>' + $('div[data-id=' + $(this).attr('data-id') + '] > input').val() + '</li>')
+                });
+                console.log(users_to_purge);
+                if (users_to_purge.length > 0) {
+                    $('#users-to-delete').append
+                    $('#confirm-modal').modal();
+                    $('#confirm-modal').one('click', '#confirm-purge', function () {
+                        for (var i = 0; i < users_to_purge.length; i++) {
+                            $.ajax({
+                                url: 'delete_all_user_history',
+                                data: { user_id: users_to_purge[i] },
+                                cache: false,
+                                async: true,
+                                success: function (data) {
+                                    var msg = "User history purged";
+                                    showMsg(msg, false, true, 2000);
+                                }
+                            });
+                        }
+                        users_list_table.draw();
+                    });
+                }
+
+                $('.edit-control').each(function () {
+                    $(this).find('button.btn-danger').toggleClass('btn-warning').toggleClass('btn-danger');
+                    $(this).addClass('hidden');
+                });
+                $('.edit-user-control > .edit-user-name').each(function () {
+                    a = $(this).children('a');
+                    input = $(this).children('input');
+                    a.text(input.val());
+                    a.removeClass('hidden');
+                    input.addClass('hidden');
+                });
+
+            } else {
+                $('.edit-control').each(function () {
+                    $(this).removeClass('hidden');
+                });
+                $('.edit-user-control > .edit-user-name').each(function () {
+                    $(this).children('a').addClass('hidden');
+                    $(this).children('input').removeClass('hidden');
+                });
+
+            }
+        });
+    });
 
     $("#refresh-users-list").click(function() {
         $.ajax({

--- a/plexpy/users.py
+++ b/plexpy/users.py
@@ -40,7 +40,9 @@ class Users(object):
                    'session_history_metadata.media_type',
                    'session_history.rating_key as rating_key',
                    'session_history_media_info.video_decision',
-                   'users.username as user'
+                   'users.username as user',
+                   'users.do_notify as do_notify',
+                   'users.keep_history as keep_history'
                    ]
         try:
             query = data_tables.ssp_query(table_name='users',
@@ -94,7 +96,9 @@ class Users(object):
                    "video_decision": item['video_decision'],
                    "user_thumb": user_thumb,
                    "user": item["user"],
-                   "user_id": item['user_id']
+                   "user_id": item['user_id'],
+                   "do_notify": helpers.checked(item['do_notify']),
+                   "keep_history": helpers.checked(item['keep_history'])
                    }
 
             rows.append(row)


### PR DESCRIPTION
From the user table, you can now:
- Change the friendly name
- Toggle notifications
- Toggle keep history
- Purge all user history (as a group selection)

**This feature is still experimental, bugs are expected!**

Show/hide users is just a blank toggle for now. I think a column like 'hide_user' needs to be added to the user database table to enable something like this.
