### PR TITLE
History tables

### DIFF
--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -1682,6 +1682,11 @@ input[type="color"],
 .history-title .popover.right .popover-content {
     padding: 5px 8px;
 }
+.history-thumbnail {
+    background-position: center;
+    background-size: cover;
+    width: 80px;
+}
 .edit-user-toggles {
     padding-right: 10px;
 }

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -14,7 +14,11 @@
             <span><i class="fa fa-history"></i> History</span>
         </div>
         <div class="button-bar">
-            <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode"><i class="fa fa-trash-o"></i> Delete mode</button>&nbsp
+            <span data-toggle="popover" data-placement="left" data-content="Data deleting does not occur until after exiting delete mode." id="delete-message">
+                <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
+                    <i class="fa fa-trash-o"></i> Delete mode
+                </button>&nbsp
+            </span>
             <div class="colvis-button-bar hidden-xs"></div>
         </div>
     </div>
@@ -42,6 +46,24 @@
         </div>
         <div class="modal fade" id="ip-info-modal" tabindex="-1" role="dialog" aria-labelledby="ip-info-modal">
         </div>
+        <div class="modal fade" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-modal">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-remove"></i></button>
+                        <h4 class="modal-title" id="myModalLabel">Confirm Purge</h4>
+                    </div>
+                    <div class="modal-body" style="text-align: center;">
+                        <p>Are you REALLY sure you want to delete this history?</p>
+                        <p>This is permanent and cannot be undone!</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-dark" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" id="confirm-delete">Purge</button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 </%def>
@@ -68,18 +90,53 @@
 
         clearSearchButton('history_table', history_table);
 
-        $('#row-edit-mode').click(function() {
+        var history_to_purge = [];
+        $('#row-edit-mode').on('click', function() {
+            $('#delete-message').popover();
+
             if ($(this).hasClass('active')) {
-                $('.delete-control').each(function() {
+                history_to_purge = [];
+                $('.delete-control button.btn-danger').map(function () {
+                    history_to_purge.push($(this).attr('data-id'));
+                });
+                if (history_to_purge.length > 0) {
+                    $('#confirm-modal').modal();
+                    $('#confirm-modal').one('click', '#confirm-delete', function () {
+                        for (var i = 0; i < history_to_purge.length; i++) {
+                            $.ajax({
+                                url: 'delete_history_rows',
+                                data: { row_id: history_to_purge[i] },
+                                async: true,
+                                success: function (data) {
+                                    var msg = "User history purged";
+                                    showMsg(msg, false, true, 2000);
+                                }
+                            });
+                        }
+                        history_table.draw();
+                    });
+                }
+
+                $('.delete-control').each(function () {
+                    $(this).find('button.btn-danger').toggleClass('btn-warning').toggleClass('btn-danger');
                     $(this).addClass('hidden');
                 });
+
             } else {
                 $('.delete-control').each(function() {
                     $(this).removeClass('hidden');
                 });
             }
         });
-    });
 
+        $(window).resize(function () {
+            if ($('.popover').popover().is(':visible')) {
+                var popover = $('.popover');
+                popover.addClass("noTransition");
+                $('#delete-message').popover('show');
+                popover.removeClass("noTransition");
+            }
+        });
+    });
 </script>
 </%def>

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -14,7 +14,7 @@
             <span><i class="fa fa-history"></i> History</span>
         </div>
         <div class="button-bar">
-            <span data-toggle="popover" data-placement="left" data-content="Data deleting does not occur until after exiting delete mode." id="delete-message">
+            <span data-toggle="popover" data-placement="left" data-content="Select rows to delete. Data is deleted upon exiting delete mode." id="delete-message">
                 <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
                     <i class="fa fa-trash-o"></i> Delete mode
                 </button>&nbsp
@@ -54,7 +54,7 @@
                         <h4 class="modal-title" id="myModalLabel">Confirm Delete</h4>
                     </div>
                     <div class="modal-body" style="text-align: center;">
-                        <p>Are you REALLY sure you want to delete this history?</p>
+                        <p>Are you REALLY sure you want to delete <strong><span id="deleteCount"></span></strong> history item(s)?</p>
                         <p>This is permanent and cannot be undone!</p>
                     </div>
                     <div class="modal-footer">
@@ -90,22 +90,18 @@
 
         clearSearchButton('history_table', history_table);
 
-        var history_to_purge = [];
         $('#row-edit-mode').on('click', function() {
             $('#delete-message').popover();
 
             if ($(this).hasClass('active')) {
-                history_to_purge = [];
-                $('.delete-control button.btn-danger').map(function () {
-                    history_to_purge.push($(this).attr('data-id'));
-                });
-                if (history_to_purge.length > 0) {
+                if (history_to_delete.length > 0) {
+                    $('#deleteCount').text(history_to_delete.length);
                     $('#confirm-modal').modal();
                     $('#confirm-modal').one('click', '#confirm-delete', function () {
-                        for (var i = 0; i < history_to_purge.length; i++) {
+                        for (var i = 0; i < history_to_delete.length; i++) {
                             $.ajax({
                                 url: 'delete_history_rows',
-                                data: { row_id: history_to_purge[i] },
+                                data: { row_id: history_to_delete[i] },
                                 async: true,
                                 success: function (data) {
                                     var msg = "User history purged";
@@ -123,6 +119,7 @@
                 });
 
             } else {
+                history_to_delete = [];
                 $('.delete-control').each(function() {
                     $(this).removeClass('hidden');
                 });

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -51,7 +51,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-remove"></i></button>
-                        <h4 class="modal-title" id="myModalLabel">Confirm Purge</h4>
+                        <h4 class="modal-title" id="myModalLabel">Confirm Delete</h4>
                     </div>
                     <div class="modal-body" style="text-align: center;">
                         <p>Are you REALLY sure you want to delete this history?</p>
@@ -59,7 +59,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-dark" data-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" id="confirm-delete">Purge</button>
+                        <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" id="confirm-delete">Delete</button>
                     </div>
                 </div>
             </div>

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -185,7 +185,7 @@ DOCUMENTATION :: END
                     <span>Watch History for <strong>${data['title']}</strong></span>
                 </div>
                 <div class="button-bar">
-                    <span data-toggle="popover" data-placement="left" data-content="Data deleting does not occur until after exiting delete mode." id="delete-message">
+                    <span data-toggle="popover" data-placement="left" data-content="Select rows to delete. Data is deleted upon exiting delete mode." id="delete-message">
                         <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
                             <i class="fa fa-trash-o"></i> Delete mode
                         </button>&nbsp
@@ -226,7 +226,7 @@ DOCUMENTATION :: END
                             <h4 class="modal-title" id="myModalLabel">Confirm Delete</h4>
                         </div>
                         <div class="modal-body" style="text-align: center;">
-                            <p>Are you REALLY sure you want to delete this history?</p>
+                            <p>Are you REALLY sure you want to delete <strong><span id="deleteCount"></span></strong> history item(s)?</p>
                             <p>This is permanent and cannot be undone!</p>
                         </div>
                         <div class="modal-footer">
@@ -303,22 +303,18 @@ DOCUMENTATION :: END
         
         clearSearchButton('history_table', history_table);
 
-        var history_to_purge = [];
         $('#row-edit-mode').on('click', function() {
             $('#delete-message').popover();
 
             if ($(this).hasClass('active')) {
-                history_to_purge = [];
-                $('.delete-control button.btn-danger').map(function () {
-                    history_to_purge.push($(this).attr('data-id'));
-                });
-                if (history_to_purge.length > 0) {
+                if (history_to_delete.length > 0) {
+                    $('#deleteCount').text(history_to_delete.length);
                     $('#confirm-modal').modal();
                     $('#confirm-modal').one('click', '#confirm-delete', function () {
-                        for (var i = 0; i < history_to_purge.length; i++) {
+                        for (var i = 0; i < history_to_delete.length; i++) {
                             $.ajax({
                                 url: 'delete_history_rows',
-                                data: { row_id: history_to_purge[i] },
+                                data: { row_id: history_to_delete[i] },
                                 async: true,
                                 success: function (data) {
                                     var msg = "User history purged";
@@ -336,6 +332,7 @@ DOCUMENTATION :: END
                 });
 
             } else {
+                history_to_delete = [];
                 $('.delete-control').each(function() {
                     $(this).removeClass('hidden');
                 });

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -185,7 +185,11 @@ DOCUMENTATION :: END
                     <span>Watch History for <strong>${data['title']}</strong></span>
                 </div>
                 <div class="button-bar">
-                    <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode"><i class="fa fa-trash-o"></i> Delete mode</button>&nbsp
+                    <span data-toggle="popover" data-placement="left" data-content="Data deleting does not occur until after exiting delete mode." id="delete-message">
+                        <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
+                            <i class="fa fa-trash-o"></i> Delete mode
+                        </button>&nbsp
+                    </span>
                     <div class="colvis-button-bar hidden-xs"></div>
                 </div>
             </div>
@@ -213,6 +217,24 @@ DOCUMENTATION :: END
             <div id="info-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="info-modal">
             </div>
             <div class="modal fade" id="ip-info-modal" tabindex="-1" role="dialog" aria-labelledby="ip-info-modal">
+            </div>
+            <div class="modal fade" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-modal">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-remove"></i></button>
+                            <h4 class="modal-title" id="myModalLabel">Confirm Delete</h4>
+                        </div>
+                        <div class="modal-body" style="text-align: center;">
+                            <p>Are you REALLY sure you want to delete this history?</p>
+                            <p>This is permanent and cannot be undone!</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-dark" data-dismiss="modal">Cancel</button>
+                            <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" id="confirm-delete">Delete</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -281,11 +303,38 @@ DOCUMENTATION :: END
         
         clearSearchButton('history_table', history_table);
 
-        $('#row-edit-mode').click(function() {
+        var history_to_purge = [];
+        $('#row-edit-mode').on('click', function() {
+            $('#delete-message').popover();
+
             if ($(this).hasClass('active')) {
-                $('.delete-control').each(function() {
+                history_to_purge = [];
+                $('.delete-control button.btn-danger').map(function () {
+                    history_to_purge.push($(this).attr('data-id'));
+                });
+                if (history_to_purge.length > 0) {
+                    $('#confirm-modal').modal();
+                    $('#confirm-modal').one('click', '#confirm-delete', function () {
+                        for (var i = 0; i < history_to_purge.length; i++) {
+                            $.ajax({
+                                url: 'delete_history_rows',
+                                data: { row_id: history_to_purge[i] },
+                                async: true,
+                                success: function (data) {
+                                    var msg = "User history purged";
+                                    showMsg(msg, false, true, 2000);
+                                }
+                            });
+                        }
+                        history_table.draw();
+                    });
+                }
+
+                $('.delete-control').each(function () {
+                    $(this).find('button.btn-danger').toggleClass('btn-warning').toggleClass('btn-danger');
                     $(this).addClass('hidden');
                 });
+
             } else {
                 $('.delete-control').each(function() {
                     $(this).removeClass('hidden');

--- a/data/interfaces/default/js/tables/history_table.js
+++ b/data/interfaces/default/js/tables/history_table.js
@@ -120,16 +120,16 @@ history_table_options = {
                     var thumb_popover = '';
                     if (rowData['media_type'] === 'movie') {
                         media_type = '<span class="media-type-tooltip" data-toggle="tooltip" title="Movie"><i class="fa fa-film fa-fw"></i></span>';
-                        thumb_popover = '<span class="thumb-tooltip" data-toggle="popover" data-img="pms_image_proxy?img=' + rowData['thumb'] + '&width=80&height=120&fallback=poster" data-height="120">' + cellData + ' (' + rowData['year'] + ')</span>'
+                        thumb_popover = '<span class="thumb-tooltip" data-toggle="popover" data-img="pms_image_proxy?img=' + rowData['thumb'] + '&width=300&height=450&fallback=poster" data-height="120">' + cellData + ' (' + rowData['year'] + ')</span>'
                         $(td).html('<div class="history-title"><a href="info?source=history&item_id=' + rowData['id'] + '"><div style="float: left;">' + media_type + '&nbsp' + thumb_popover + '</div></a></div>');
                     } else if (rowData['media_type'] === 'episode') {
                         media_type = '<span class="media-type-tooltip" data-toggle="tooltip" title="Episode"><i class="fa fa-television fa-fw"></i></span>';
-                        thumb_popover = '<span class="thumb-tooltip" data-toggle="popover" data-img="pms_image_proxy?img=' + rowData['thumb'] + '&width=80&height=120&fallback=poster" data-height="120">' + cellData + ' \
+                        thumb_popover = '<span class="thumb-tooltip" data-toggle="popover" data-img="pms_image_proxy?img=' + rowData['thumb'] + '&width=300&height=450&fallback=poster" data-height="120">' + cellData + ' \
                             (S' + ('00' + rowData['parent_media_index']).slice(-2) + 'E' + ('00' + rowData['media_index']).slice(-2) + ')</span>'
                         $(td).html('<div class="history-title"><a href="info?source=history&item_id=' + rowData['id'] + '"><div style="float: left;" >' + media_type + '&nbsp' + thumb_popover + '</div></a></div>');
                     } else if (rowData['media_type'] === 'track') {
                         media_type = '<span class="media-type-tooltip" data-toggle="tooltip" title="Track"><i class="fa fa-music fa-fw"></i></span>';
-                        thumb_popover = '<span class="thumb-tooltip" data-toggle="popover" data-img="pms_image_proxy?img=' + rowData['thumb'] + '&width=80&height=80&fallback=poster" data-height="80">' + cellData + ' (' + rowData['parent_title'] + ')</span>'
+                        thumb_popover = '<span class="thumb-tooltip" data-toggle="popover" data-img="pms_image_proxy?img=' + rowData['thumb'] + '&width=300&height=300&fallback=poster" data-height="80">' + cellData + ' (' + rowData['parent_title'] + ')</span>'
                         $(td).html('<div class="history-title"><div style="float: left;">' + media_type + '&nbsp' + thumb_popover + '</div></div>');
                     } else {
                         $(td).html('<a href="info?item_id=' + rowData['id'] + '">' + cellData + '</a>');
@@ -226,7 +226,7 @@ history_table_options = {
             trigger: 'hover',
             placement: 'right',
             content: function () {
-                return '<div style="background-image: url(' + $(this).data('img') + '); width: 80px; height: ' + $(this).data('height') + 'px;" />';
+                return '<div class="history-thumbnail" style="background-image: url(' + $(this).data('img') + '); height: ' + $(this).data('height') + 'px;" />';
             }
         });
 

--- a/data/interfaces/default/js/tables/history_table.js
+++ b/data/interfaces/default/js/tables/history_table.js
@@ -32,7 +32,7 @@ history_table_options = {
             "targets": [0],
             "data": null,
             "createdCell": function (td, cellData, rowData, row, col) {
-                $(td).html('<button class="btn btn-xs btn-danger" data-id="' + rowData['id'] + '"><i class="fa fa-trash-o"></i> Delete</button>');
+                $(td).html('<button class="btn btn-xs btn-warning" data-id="' + rowData['id'] + '"><i class="fa fa-trash-o fa-fw"></i> Delete</button>');
             },
             "width": "5%",
             "className": "delete-control no-wrap hidden",
@@ -98,11 +98,11 @@ history_table_options = {
                 if (cellData !== '') {
                     var transcode_dec = '';
                     if (rowData['video_decision'] === 'transcode') {
-                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Transcode"><i class="fa fa-server fa-fw"></i></span>&nbsp';
+                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Transcode"><i class="fa fa-server fa-fw"></i></span>';
                     } else if (rowData['video_decision'] === 'copy') {
-                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Stream"><i class="fa fa-video-camera fa-fw"></i></span>&nbsp';
+                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Stream"><i class="fa fa-video-camera fa-fw"></i></span>';
                     } else if (rowData['video_decision'] === 'direct play' || rowData['video_decision'] === '') {
-                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Play"><i class="fa fa-play-circle fa-fw"></i></span>&nbsp';
+                        transcode_dec = '<span class="transcode-tooltip" data-toggle="tooltip" title="Direct Play"><i class="fa fa-play-circle fa-fw"></i></span>';
                     }
                     $(td).html('<div><a href="#" data-target="#info-modal" data-toggle="modal"><div style="float: left;">' + transcode_dec + '&nbsp' + cellData + '</div></a></div>');
                 }
@@ -287,16 +287,9 @@ $('#history_table').on('click', 'td.delete-control > button', function () {
     var row = history_table.row( tr );
     var rowData = row.data();
 
-    $(this).prop('disabled', true);
-    $(this).html('<i class="fa fa-spin fa-refresh"></i> Delete');
-
-    $.ajax({
-        url: 'delete_history_rows',
-        data: {row_id: rowData['id']},
-        async: true,
-        success: function(data) {
-            history_table.ajax.reload(null, false);
-        }
-    });
-
+    if ($(this).hasClass('active')) {
+        $(this).toggleClass('btn-warning').toggleClass('btn-danger');
+    } else {
+        $(this).toggleClass('btn-danger').toggleClass('btn-warning');
+    }
 });

--- a/data/interfaces/default/js/tables/history_table.js
+++ b/data/interfaces/default/js/tables/history_table.js
@@ -1,5 +1,6 @@
 var date_format = 'YYYY-MM-DD';
 var time_format = 'hh:mm a';
+var history_to_delete = [];
 
 $.ajax({
     url: 'get_date_formats',
@@ -18,7 +19,7 @@ history_table_options = {
         "info":"Showing _START_ to _END_ of _TOTAL_ history items",
         "infoEmpty":"Showing 0 to 0 of 0 entries",
         "infoFiltered":"(filtered from _MAX_ total entries)",
-        "emptyTable": "No data in table",
+        "emptyTable": "No data in table"
     },
     "pagingType": "bootstrap",
     "stateSave": true,
@@ -238,6 +239,11 @@ history_table_options = {
     "preDrawCallback": function(settings) {
         var msg = "<div class='msg'><i class='fa fa-refresh fa-spin'></i>&nbspFetching rows...</div>";
         showMsg(msg, false, false, 0)
+    },
+    "rowCallback": function (row, rowData) {
+        if ($.inArray(rowData['id'], history_to_delete) !== -1) {
+            $(row).find('button[data-id="' + rowData['id'] + '"]').toggleClass('btn-warning').toggleClass('btn-danger');
+        }
     }
 }
 
@@ -287,9 +293,11 @@ $('#history_table').on('click', 'td.delete-control > button', function () {
     var row = history_table.row( tr );
     var rowData = row.data();
 
-    if ($(this).hasClass('active')) {
-        $(this).toggleClass('btn-warning').toggleClass('btn-danger');
+    var index = $.inArray(rowData['id'], history_to_delete);
+    if (index === -1) {
+        history_to_delete.push(rowData['id']);
     } else {
-        $(this).toggleClass('btn-danger').toggleClass('btn-warning');
+        history_to_delete.splice(index, 1);
     }
+    $(this).toggleClass('btn-warning').toggleClass('btn-danger');
 });

--- a/data/interfaces/default/js/tables/users.js
+++ b/data/interfaces/default/js/tables/users.js
@@ -271,7 +271,6 @@ $('#users_list_table').on('click', 'td.edit-control > .edit-user-toggles > butto
     var row = users_list_table.row(tr);
     var rowData = row.data();
 
-    //$(this).prop('disabled', true);
     if ($(this).hasClass('active')) {
         $(this).toggleClass('btn-warning').toggleClass('btn-danger');
     } else {

--- a/data/interfaces/default/user.html
+++ b/data/interfaces/default/user.html
@@ -155,7 +155,7 @@ from plexpy import helpers
                             </strong></span>
                         </div>
                         <div class="button-bar">
-                            <span data-toggle="popover" data-placement="left" data-content="Data deleting does not occur until after exiting delete mode." id="delete-message">
+                            <span data-toggle="popover" data-placement="left" data-content="Select rows to delete. Data is deleted upon exiting delete mode." id="delete-message">
                                 <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
                                     <i class="fa fa-trash-o"></i> Delete mode
                                 </button>&nbsp
@@ -239,7 +239,7 @@ from plexpy import helpers
                     <h4 class="modal-title" id="myModalLabel">Confirm Delete</h4>
                 </div>
                 <div class="modal-body" style="text-align: center;">
-                    <p>Are you REALLY sure you want to delete this history?</p>
+                    <p>Are you REALLY sure you want to delete <strong><span id="deleteCount"></span></strong> history item(s)?</p>
                     <p>This is permanent and cannot be undone!</p>
                 </div>
                 <div class="modal-footer">
@@ -390,22 +390,18 @@ from plexpy import helpers
             });
         });
 
-        var history_to_purge = [];
         $('#row-edit-mode').on('click', function() {
             $('#delete-message').popover();
 
             if ($(this).hasClass('active')) {
-                history_to_purge = [];
-                $('.delete-control button.btn-danger').map(function () {
-                    history_to_purge.push($(this).attr('data-id'));
-                });
-                if (history_to_purge.length > 0) {
+                if (history_to_delete.length > 0) {
+                    $('#deleteCount').text(history_to_delete.length);
                     $('#confirm-modal').modal();
                     $('#confirm-modal').one('click', '#confirm-delete', function () {
-                        for (var i = 0; i < history_to_purge.length; i++) {
+                        for (var i = 0; i < history_to_delete.length; i++) {
                             $.ajax({
                                 url: 'delete_history_rows',
-                                data: { row_id: history_to_purge[i] },
+                                data: { row_id: history_to_delete[i] },
                                 async: true,
                                 success: function (data) {
                                     var msg = "User history purged";
@@ -423,6 +419,7 @@ from plexpy import helpers
                 });
 
             } else {
+                history_to_delete = [];
                 $('.delete-control').each(function() {
                     $(this).removeClass('hidden');
                 });

--- a/data/interfaces/default/user.html
+++ b/data/interfaces/default/user.html
@@ -155,7 +155,11 @@ from plexpy import helpers
                             </strong></span>
                         </div>
                         <div class="button-bar">
-                            <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode"><i class="fa fa-trash-o"></i> Delete Mode</button>&nbsp
+                            <span data-toggle="popover" data-placement="left" data-content="Data deleting does not occur until after exiting delete mode." id="delete-message">
+                                <button class="btn btn-danger" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
+                                    <i class="fa fa-trash-o"></i> Delete mode
+                                </button>&nbsp
+                            </span>
                             <div class="colvis-button-bar hidden-xs" id="button-bar-history">
                         </div>
                         </div>
@@ -226,6 +230,24 @@ from plexpy import helpers
     <div class="modal fade" id="info-modal" tabindex="-1" role="dialog" aria-labelledby="info-modal">
     </div>
     <div class="modal fade" id="ip-info-modal" tabindex="-1" role="dialog" aria-labelledby="ip-info-modal">
+    </div>
+    <div class="modal fade" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-modal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-remove"></i></button>
+                    <h4 class="modal-title" id="myModalLabel">Confirm Delete</h4>
+                </div>
+                <div class="modal-body" style="text-align: center;">
+                    <p>Are you REALLY sure you want to delete this history?</p>
+                    <p>This is permanent and cannot be undone!</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-dark" data-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" id="confirm-delete">Delete</button>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <footer></footer>
@@ -368,12 +390,38 @@ from plexpy import helpers
             });
         });
 
-        // Delete mode button
-        $('#row-edit-mode').click(function() {
+        var history_to_purge = [];
+        $('#row-edit-mode').on('click', function() {
+            $('#delete-message').popover();
+
             if ($(this).hasClass('active')) {
-                $('.delete-control').each(function() {
+                history_to_purge = [];
+                $('.delete-control button.btn-danger').map(function () {
+                    history_to_purge.push($(this).attr('data-id'));
+                });
+                if (history_to_purge.length > 0) {
+                    $('#confirm-modal').modal();
+                    $('#confirm-modal').one('click', '#confirm-delete', function () {
+                        for (var i = 0; i < history_to_purge.length; i++) {
+                            $.ajax({
+                                url: 'delete_history_rows',
+                                data: { row_id: history_to_purge[i] },
+                                async: true,
+                                success: function (data) {
+                                    var msg = "User history purged";
+                                    showMsg(msg, false, true, 2000);
+                                }
+                            });
+                        }
+                        history_table.draw();
+                    });
+                }
+
+                $('.delete-control').each(function () {
+                    $(this).find('button.btn-danger').toggleClass('btn-warning').toggleClass('btn-danger');
                     $(this).addClass('hidden');
                 });
+
             } else {
                 $('.delete-control').each(function() {
                     $(this).removeClass('hidden');

--- a/data/interfaces/default/users.html
+++ b/data/interfaces/default/users.html
@@ -97,7 +97,6 @@
                     users_to_purge.push($(this).attr('data-id'));
                     ul.append('<li>' + $('div[data-id=' + $(this).attr('data-id') + '] > input').val() + '</li>')
                 });
-                console.log(users_to_purge);
                 if (users_to_purge.length > 0) {
                     $('#users-to-delete').append
                     $('#confirm-modal').modal();


### PR DESCRIPTION
I think the confirm modal should me moved into it's own file (similar to the ip address and stream detail modals) since we are using in everywhere.

I'm not that good with the back-end python stuff, so I'm not sure how to implement it. But I can try, just copy and paste the code for the other modals?
