### PR TITLE
Change to notify stopped only if less than watched percent

### DIFF
--- a/data/interfaces/default/current_activity.html
+++ b/data/interfaces/default/current_activity.html
@@ -106,7 +106,12 @@ DOCUMENTATION :: END
             </div>
             <div id="stream-${a['session_key']}" class="dashboard-activity-info-details-overlay">
                 <div class="dashboard-activity-info-details-content">
-                    <div class="dashboard-activity-info-platform" id="platform-${a['session_key']}">
+                    <div id="platform-${a['session_key']}" title="${a['platform']}">
+                        <script>
+                            $("#platform-${a['session_key']}").html("<div class='dashboard-activity-info-platform-box' style='background-image: url(" + getPlatformImagePath('${a['platform']}') + ");'>");
+                        </script>
+                    </div>
+                    <div class="dashboard-activity-info-platform">
                         <strong>${a['player']}</strong><br />
                         % if a['state'] == 'playing':
                         State &nbsp;<strong>Playing</strong>
@@ -249,9 +254,6 @@ DOCUMENTATION :: END
         </div>
 </div>
 </div>
-<script>
-    $("#platform-${a['session_key']}").prepend("<div class='dashboard-activity-info-platform-box' style='background-image: url(" + getPlatformImagePath('${a['platform']}') + ");'>");
-</script>
 
 % endfor
 <script>

--- a/data/interfaces/default/history_table_modal.html
+++ b/data/interfaces/default/history_table_modal.html
@@ -38,6 +38,7 @@
             type: "post",
             data: function ( d ) {
                 return { 'json_data': JSON.stringify( d ),
+                         'grouping': false,
                          'start_date': '${data}'
                        };
             }

--- a/data/interfaces/default/js/script.js
+++ b/data/interfaces/default/js/script.js
@@ -213,11 +213,11 @@ function getPlatformImagePath(platformName) {
         return 'interfaces/default/images/platforms/opera.png';
     } else if (platformName.indexOf("KODI") > -1) {
         return 'interfaces/default/images/platforms/kodi.png';
-    } else if (platformName.indexOf("Mystery 3") > -1) {
+    } else if (platformName.indexOf("Playstation 3") > -1) {
         return 'interfaces/default/images/platforms/playstation.png';
-    } else if (platformName.indexOf("Mystery 4") > -1) {
+    } else if (platformName.indexOf("Playstation 4") > -1) {
         return 'interfaces/default/images/platforms/playstation.png';
-	} else if (platformName.indexOf("Mystery 5") > -1) {
+	} else if (platformName.indexOf("Xbox 360") > -1) {
         return 'interfaces/default/images/platforms/xbox.png';
 	} else if (platformName.indexOf("Windows") > -1) {
 	    return 'interfaces/default/images/platforms/win8.png';

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -496,6 +496,12 @@ available_notification_agents = notifiers.available_notification_agents()
                             </div>
                             <p class="help-block">Set the progress percentage of when a watched notification should be triggered. Minimum 50, Maximum 95.</p>
                         </div>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="notify_consecutive" id="notify_consecutive" value="1" ${config['notify_consecutive']}> Allow Consecutive Notifications
+                            </label>
+                            <p class="help-block">Disable to prevent consecutive notifications (i.e. both watched &amp; stopped notifications).</p>
+                        </div>
 
                         <div class="padded-header">
                             <h3>Custom Notification Messages</h3>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -312,7 +312,7 @@ available_notification_agents = notifiers.available_notification_agents()
                                     <input type="text" class="form-control" id="pms_logs_folder" name="pms_logs_folder" value="${config['pms_logs_folder']}" size="30" data-parsley-trigger="change">
                                 </div>
                             </div>
-                            <p class="help-block">Set the folder where your Plex Server logs are. This is required if you enable IP logging.<br /><a href="https://support.plex.tv/hc/en-us/articles/200250417-Plex-Media-Server-Log-Files" target="_blank">Click here</a> for help.</p>
+                            <p class="help-block">Set the complete folder path where your Plex Server logs are, shortcuts are not recognized.<br /><a href="https://support.plex.tv/hc/en-us/articles/200250417-Plex-Media-Server-Log-Files" target="_blank">Click here</a> for help. This is required if you enable IP logging. </p>
                         </div>
 
                         <input type="hidden" id="pms_identifier" name="pms_identifier" value="${config['pms_identifier']}">

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -122,6 +122,7 @@ _CONFIG_DEFINITIONS = {
     'NMA_ON_RESUME': (int, 'NMA', 0),
     'NMA_ON_BUFFER': (int, 'NMA', 0),
     'NMA_ON_WATCHED': (int, 'NMA', 0),
+    'NOTIFY_CONSECUTIVE': (int, 'Monitoring', 1),
     'NOTIFY_WATCHED_PERCENT': (int, 'Monitoring', 85),
     'NOTIFY_ON_START_SUBJECT_TEXT': (str, 'Monitoring', 'PlexPy ({server_name})'),
     'NOTIFY_ON_START_BODY_TEXT': (str, 'Monitoring', '{user} ({player}) started playing {title}.'),

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -502,11 +502,17 @@ class DataFactory(object):
                     return None
 
                 for item in result:
+                    # Rename Mystery platform names
+                    platform_names = {'Mystery 3': 'Playstation 3',
+                                      'Mystery 4': 'Playstation 4',
+                                      'Mystery 5': 'Xbox 360'}
+                    platform_type = platform_names.get(item[0], item[0])
+
                     row = {'platform': item[0],
                            'total_plays': item[1],
                            'total_duration': item[2],
                            'last_play': item[3],
-                           'platform_type': item[0],
+                           'platform_type': platform_type,
                            'title': '',
                            'thumb': '',
                            'grandparent_thumb': '',

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -1070,6 +1070,13 @@ class PmsConnect(object):
         else:
             logger.warn(u"No known stream types found in session list.")
 
+        # Rename Mystery platform names
+        platform_names = {'Mystery 3': 'Playstation 3',
+                          'Mystery 4': 'Playstation 4',
+                          'Mystery 5': 'Xbox 360'}
+        session_output['platform'] = platform_names.get(session_output['platform'], 
+                                                        session_output['platform'])
+
         return session_output
 
     """

--- a/plexpy/users.py
+++ b/plexpy/users.py
@@ -516,8 +516,14 @@ class Users(object):
             return None
 
         for item in result:
+            # Rename Mystery platform names
+            platform_names = {'Mystery 3': 'Playstation 3',
+                              'Mystery 4': 'Playstation 4',
+                              'Mystery 5': 'Xbox 360'}
+            platform_type = platform_names.get(item[2], item[2])
+
             row = {'platform_name': item[0],
-                   'platform_type': item[2],
+                   'platform_type': platform_type,
                    'total_plays': item[1],
                    'result_id': result_id
                    }

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -439,6 +439,7 @@ class WebInterface(object):
             "music_logging_enable": checked(plexpy.CONFIG.MUSIC_LOGGING_ENABLE),
             "logging_ignore_interval": plexpy.CONFIG.LOGGING_IGNORE_INTERVAL,
             "pms_is_remote": checked(plexpy.CONFIG.PMS_IS_REMOTE),
+            "notify_consecutive": checked(plexpy.CONFIG.NOTIFY_CONSECUTIVE),
             "notify_watched_percent": plexpy.CONFIG.NOTIFY_WATCHED_PERCENT,
             "notify_on_start_subject_text": plexpy.CONFIG.NOTIFY_ON_START_SUBJECT_TEXT,
             "notify_on_start_body_text": plexpy.CONFIG.NOTIFY_ON_START_BODY_TEXT,
@@ -476,7 +477,7 @@ class WebInterface(object):
             "tv_notify_on_stop", "movie_notify_on_stop", "music_notify_on_stop",
             "tv_notify_on_pause", "movie_notify_on_pause", "music_notify_on_pause", "refresh_users_on_startup",
             "ip_logging_enable", "video_logging_enable", "music_logging_enable", "pms_is_remote", "home_stats_type",
-            "group_history_tables"
+            "group_history_tables", "notify_consecutive"
         ]
         for checked_config in checked_configs:
             if checked_config not in kwargs:


### PR DESCRIPTION
- Also fix paused notifications sending at the end of items (right
  before stopping)

Let's try this again. It only stops the notification right before it sends the notification (in `notification_handler`, and still writes the notification to `notify_log`.
