### PR TITLE
Player in tables and top level info pages

### DIFF
--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -961,14 +961,24 @@ a:hover .dashboard-recent-media-cover {
     white-space: nowrap;
     overflow: hidden;
 }
-.summary-navbar-list span {
-    display: inline-block;
-    margin-right: 15px;
+.summary-navbar-list .breadcrumb {
+    padding: 0;
+    margin: 0;
+    background: none;
 }
-.summary-navbar-list span a {
+.summary-navbar-list .breadcrumb > li + li:before {
+    color: #444;
+    font-family: FontAwesome;
+    content: "\f054";
+    padding: 0 15px;
+}
+.summary-navbar-list .breadcrumb > .active {
+    color: #eee;
+}
+.summary-navbar-list .breadcrumb a {
     color: #999;
 }
-.summary-navbar-list span a:hover {
+.summary-navbar-list .breadcrumb a:hover {
     color: #F9AA03;
 }
 .summary-content-title-wrapper {

--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -1565,19 +1565,19 @@ a:hover .item-children-poster {
     top: 3px;
     left: 3px;
 }
-.user-platforms ul {
+.user-player ul {
     list-style: none;
     margin: 0;
 }
-.user-platforms-instance {
+.user-player-instance {
     float: left;
     width: 240px;
     height: 80px;
     margin-bottom: 25px;
 }
-.user-platforms-instance li {
+.user-player-instance li {
 }
-.user-platforms-instance-box {
+.user-player-instance-box {
     float: left;
     width: 75px;
     border-radius: 3px;
@@ -1589,7 +1589,7 @@ a:hover .item-children-poster {
     height: 80px;
     width: 80px;
 }
-.user-platforms-instance-name {
+.user-player-instance-name {
     float: left;
     padding-top: 14px;
     color: #fff;
@@ -1602,7 +1602,7 @@ a:hover .item-children-poster {
     width: 140px;
     margin-left: 10px;
 }
-.user-platforms-instance-playcount h3 {
+.user-player-instance-playcount h3 {
     font-size: 30px;
     font-weight: bold;
     color: #F9AA03;
@@ -1612,7 +1612,7 @@ a:hover .item-children-poster {
     margin: 0 5px 0 10px;
     float: left;
 }
-.user-platforms-instance-playcount p {
+.user-player-instance-playcount p {
     color: #aaa;
     font-size: 12px;
     float: left;

--- a/data/interfaces/default/current_activity.html
+++ b/data/interfaces/default/current_activity.html
@@ -137,9 +137,9 @@ DOCUMENTATION :: END
                         <br />
                         % if a['audio_decision'] == 'direct play':
                         Audio &nbsp;<strong>Direct Play (${a['audio_codec']}) (${a['audio_channels']}ch)</strong>
-                        % elif a['audio_decision'] == 'Copy':
+                        % elif a['audio_decision'] == 'copy':
                         Audio &nbsp;<strong>Direct Stream (${a['transcode_audio_codec']}) (${a['transcode_audio_channels']}ch)</strong>
-                        % elif a['audio_decision'] != 'transcode':
+                        % elif a['audio_decision'] == 'transcode':
                         Audio &nbsp;<strong>Transcode (${a['transcode_audio_codec']}) (${a['transcode_audio_channels']}ch)</strong>
                         % endif
                     % elif a['media_type'] == 'episode' or a['media_type'] == 'movie' or a['media_type'] == 'clip':

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -30,6 +30,7 @@
                 <th align='left' id="friendly_name">User</th>
                 <th align='left' id="ip_address">IP Address</th>
                 <th align='left' id="platform">Platform</th>
+                <th align='left' id="device">Player</th>
                 <th align='left' id="title">Title</th>
                 <th align='left' id="started">Started</th>
                 <th align='left' id="paused_counter">Paused</th>
@@ -84,7 +85,7 @@
             }
         }
         history_table = $('#history_table').DataTable(history_table_options);
-        var colvis = new $.fn.dataTable.ColVis(history_table, { buttonText: '<i class="fa fa-columns"></i> Select columns', buttonClass: 'btn btn-dark', exclude: [0, 10] });
+        var colvis = new $.fn.dataTable.ColVis(history_table, { buttonText: '<i class="fa fa-columns"></i> Select columns', buttonClass: 'btn btn-dark', exclude: [0, 11] });
         $(colvis.button()).appendTo('div.colvis-button-bar');
 
         clearSearchButton('history_table', history_table);

--- a/data/interfaces/default/history_table_modal.html
+++ b/data/interfaces/default/history_table_modal.html
@@ -16,7 +16,7 @@
                     <th align='left' id="started">Started</th>
                     <th align='left' id="stopped">Stopped</th>
                     <th align='left' id="friendly_name">User</th>
-                    <th align='left' id="platform">Platform</th>
+                    <th align='left' id="player">Player</th>
                     <th align='left' id="title">Title</th>
                 </tr>
                 </thead>

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -333,6 +333,7 @@ DOCUMENTATION :: END
                                     <th align='left' id="friendly_name">User</th>
                                     <th align='left' id="ip_address">IP Address</th>
                                     <th align='left' id="platform">Platform</th>
+                                    <th align='left' id="player">Player</th>
                                     <th align='left' id="title">Title</th>
                                     <th align='left' id="started">Started</th>
                                     <th align='left' id="paused_counter">Paused</th>
@@ -550,7 +551,7 @@ DOCUMENTATION :: END
     $(document).ready(function () {
         get_history();
         history_table = $('#history_table').DataTable(history_table_options);
-        var colvis = new $.fn.dataTable.ColVis(history_table, { buttonText: '<i class="fa fa-columns"></i> Select columns', buttonClass: 'btn btn-dark', exclude: [0, 10] });
+        var colvis = new $.fn.dataTable.ColVis(history_table, { buttonText: '<i class="fa fa-columns"></i> Select columns', buttonClass: 'btn btn-dark', exclude: [0, 11] });
         $(colvis.button()).appendTo('div.colvis-button-bar');
 
         clearSearchButton('history_table', history_table);

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -67,55 +67,44 @@ DOCUMENTATION :: END
             <div class="summary-navbar">
                 <div class="col-md-12">
                     <div class="summary-navbar-list">
+                        <ul class="list-unstyled breadcrumb">
                         % if data['type'] == 'library':
                         % if data['library'] == 'movie':
-                        <span><a href="#">Movies</a></span>
+                        <li class="active">Movies</li>
                         % elif data['library'] == 'show':
-                        <span><a href="#">TV Shows</a></span>
+                        <li class="active">TV Shows</li>
                         % elif data['library'] == 'artist':
-                        <span><a href="#">Music</a></span>
+                        <li class="active">Music</li>
                         % endif
                         % elif data['type'] == 'movie':
-                        <span><a href="info?item_id=movie">Movies</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">${data['title']}</a></span>
+                        <li><a href="info?item_id=movie">Movies</a></li>
+                        <li class="active">${data['title']}</li>
                         % elif data['type'] == 'show':
-                        <span><a href="info?item_id=show">TV Shows</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">${data['title']}</a></span>
+                        <li><a href="info?item_id=show">TV Shows</a></li>
+                        <li class="active">${data['title']}</li>
                         % elif data['type'] == 'season':
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=show">TV Shows</a></span>
-                        <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">Season ${data['index']}</a></span>
+                        <li class="hidden-xs hidden-sm"><a href="info?item_id=show">TV Shows</a></li>
+                        <li><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></li>
+                        <li class="active">Season ${data['index']}</li>
                         % elif data['type'] == 'episode':
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=show">TV Shows</a></span>
-                        <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></span>
-                        <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="info?item_id=${data['parent_rating_key']}">Season ${data['parent_index']}</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">Episode ${data['index']} - ${data['title']}</a></span>
+                        <li class="hidden-xs hidden-sm"><a href="info?item_id=show">TV Shows</a></li>
+                        <li class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></li>
+                        <li><a href="info?item_id=${data['parent_rating_key']}">Season ${data['parent_index']}</a></li>
+                        <li class="active">Episode ${data['index']} - ${data['title']}</li>
                         % elif data['type'] == 'artist':
-                        <span><a href="info?item_id=artist">Music</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">${data['title']}</a></span>
+                        <li><a href="info?item_id=artist">Music</a></li>
+                        <li class="active">${data['title']}</li>
                         % elif data['type'] == 'album':
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=artist">Music</a></span>
-                        <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">${data['title']}</a></span>
+                        <li class="hidden-xs hidden-sm"><a href="info?item_id=artist">Music</a></li>
+                        <li><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></li>
+                        <li class="active">${data['title']}</li>
                         % elif data['type'] == 'track':
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=artist">Music</a></span>
-                        <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></span>
-                        <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></span>
-                        <span><i class="fa fa-chevron-right"></i></span>
-                        <span><a href="#">Track ${data['index']} - ${data['title']}</a></span>
+                        <li class="hidden-xs hidden-sm"><a href="info?item_id=artist">Music</a></li>
+                        <li class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></li>
+                        <li><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></li>
+                        <li class="active">Track ${data['index']} - ${data['title']}</li>
                         % endif
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -60,27 +60,37 @@ DOCUMENTATION :: END
 % if data:
 <div class="container-fluid">
     <div class="row">
+        % if data['type'] != 'library':
         <div class="art-face" style="background-image:url(pms_image_proxy?img=${data['art']}&width=1920&height=1080)"></div>
+        % endif
         <div class="summary-container">
             <div class="summary-navbar">
                 <div class="col-md-12">
                     <div class="summary-navbar-list">
-                        % if data['type'] == 'movie':
-                        <span>Movies</span>
+                        % if data['type'] == 'library':
+                        % if data['library'] == 'movie':
+                        <span><a href="#">Movies</a></span>
+                        % elif data['library'] == 'show':
+                        <span><a href="#">TV Shows</a></span>
+                        % elif data['library'] == 'music':
+                        <span><a href="#">Music</a></span>
+                        % endif
+                        % elif data['type'] == 'movie':
+                        <span><a href="info?item_id=movie">Movies</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">${data['title']}</a></span>
                         % elif data['type'] == 'show':
-                        <span>TV Shows</span>
+                        <span><a href="info?item_id=show">TV Shows</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">${data['title']}</a></span>
                         % elif data['type'] == 'season':
-                        <span class="hidden-xs hidden-sm">TV Shows</span>
+                        <span class="hidden-xs hidden-sm"><a href="info?item_id=show">TV Shows</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
                         <span><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">Season ${data['index']}</a></span>
                         % elif data['type'] == 'episode':
-                        <span class="hidden-xs hidden-sm">TV Shows</span>
+                        <span class="hidden-xs hidden-sm"><a href="info?item_id=show">TV Shows</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
                         <span class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
@@ -88,17 +98,17 @@ DOCUMENTATION :: END
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">Episode ${data['index']} - ${data['title']}</a></span>
                         % elif data['type'] == 'artist':
-                        <span>Music</span>
+                        <span><a href="info?item_id=music">Music</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">${data['title']}</a></span>
                         % elif data['type'] == 'album':
-                        <span class="hidden-xs hidden-sm">Music</span>
+                        <span class="hidden-xs hidden-sm"><a href="info?item_id=music">Music</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
                         <span><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">${data['title']}</a></span>
                         % elif data['type'] == 'track':
-                        <span class="hidden-xs hidden-sm">Music</span>
+                        <span class="hidden-xs hidden-sm"><a href="info?item_id=music">Music</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
                         <span class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
@@ -109,12 +119,13 @@ DOCUMENTATION :: END
                     </div>
                 </div>
             </div>
+            % if data['type'] != 'library':
             <div class="summary-content-title-wrapper">
                 <div class="col-md-9">
                     <div class="summary-content-poster hidden-xs hidden-sm">
                         % if data['type'] == 'track':
                         <a href="http://app.plex.tv/web/app#!/server/${config['pms_identifier']}/details/%2Flibrary%2Fmetadata%2F${data['parent_rating_key']}" target="Plex/Web" title="View in Plex/Web">
-                        % else:
+                        % elif data['type'] != 'library':
                         <a href="http://app.plex.tv/web/app#!/server/${config['pms_identifier']}/details/%2Flibrary%2Fmetadata%2F${data['rating_key']}" target="Plex/Web" title="View in Plex/Web">
                         % endif
                             % if data['type'] == 'episode':
@@ -129,7 +140,7 @@ DOCUMENTATION :: END
                                     <span></span>
                                 </div>
                             </div>
-                            % else:
+                            % elif data['type'] != 'library':
                             <div class="summary-poster-face" style="background-image: url(pms_image_proxy?img=${data['thumb']}&width=300&height=450&fallback=poster);">
                                 <div class="summary-poster-face-overlay">
                                     <span></span>
@@ -159,7 +170,9 @@ DOCUMENTATION :: END
                     </div>
                 </div>
             </div>
+            % endif
             <div class="summary-content-wrapper">
+                % if data['type'] != 'library':
                 <div class="col-md-9">
                     % if data['type'] == 'movie' or data['type'] == 'show' or data['type'] == 'season':
                     <div class="summary-content-padding hidden-xs hidden-sm" style="height: 275px;"></div>
@@ -310,6 +323,7 @@ DOCUMENTATION :: END
                         <div id="children-list"><i class="fa fa-refresh fa-spin"></i>&nbsp; Loading track list...</div>
                     </div>
                 </div>
+                % endif
                 % endif
                 <div class='col-md-12'>
                     <div class='table-card-header'>
@@ -507,7 +521,20 @@ DOCUMENTATION :: END
 
 % if data:
 <script src="interfaces/default/js/tables/history_table.js"></script>
-% if data['type'] == 'show' or data['type'] == 'artist':
+% if data['type'] == 'library':
+<script>
+    function get_history() {
+        history_table_options.ajax = {
+            "url": "get_history",
+            type: 'post',
+            data: function ( d ) {
+                return { 'json_data': JSON.stringify( d ),
+                    'media_type': '${data['media_type']}' };
+            }
+        }
+    }
+</script>
+% elif data['type'] == 'show' or data['type'] == 'artist':
 <script>
     function get_history() {
         history_table_options.ajax = {
@@ -606,7 +633,7 @@ DOCUMENTATION :: END
     });
 </script>
 % endif
-% if data['rating']:
+% if data['type'] != 'library' and data['rating']:
 <script>
     // Convert rating to 5 star rating type
     var starRating = Math.round(${data['rating']} / 2);

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -72,7 +72,7 @@ DOCUMENTATION :: END
                         <span><a href="#">Movies</a></span>
                         % elif data['library'] == 'show':
                         <span><a href="#">TV Shows</a></span>
-                        % elif data['library'] == 'music':
+                        % elif data['library'] == 'artist':
                         <span><a href="#">Music</a></span>
                         % endif
                         % elif data['type'] == 'movie':
@@ -98,17 +98,17 @@ DOCUMENTATION :: END
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">Episode ${data['index']} - ${data['title']}</a></span>
                         % elif data['type'] == 'artist':
-                        <span><a href="info?item_id=music">Music</a></span>
+                        <span><a href="info?item_id=artist">Music</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">${data['title']}</a></span>
                         % elif data['type'] == 'album':
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=music">Music</a></span>
+                        <span class="hidden-xs hidden-sm"><a href="info?item_id=artist">Music</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
                         <span><a href="info?item_id=${data['parent_rating_key']}">${data['parent_title']}</a></span>
                         <span><i class="fa fa-chevron-right"></i></span>
                         <span><a href="#">${data['title']}</a></span>
                         % elif data['type'] == 'track':
-                        <span class="hidden-xs hidden-sm"><a href="info?item_id=music">Music</a></span>
+                        <span class="hidden-xs hidden-sm"><a href="info?item_id=artist">Music</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>
                         <span class="hidden-xs hidden-sm"><a href="info?item_id=${data['grandparent_rating_key']}">${data['grandparent_title']}</a></span>
                         <span class="hidden-xs hidden-sm"><i class="fa fa-chevron-right"></i></span>

--- a/data/interfaces/default/js/script.js
+++ b/data/interfaces/default/js/script.js
@@ -217,13 +217,13 @@ function getPlatformImagePath(platformName) {
         return 'interfaces/default/images/platforms/playstation.png';
     } else if (platformName.indexOf("Playstation 4") > -1) {
         return 'interfaces/default/images/platforms/playstation.png';
-	} else if (platformName.indexOf("Xbox 360") > -1) {
+    } else if (platformName.indexOf("Xbox 360") > -1) {
         return 'interfaces/default/images/platforms/xbox.png';
-	} else if (platformName.indexOf("Windows") > -1) {
-	    return 'interfaces/default/images/platforms/win8.png';
-	} else if (platformName.indexOf("Windows phone") > -1) {
-	    return 'interfaces/default/images/platforms/wp.png';
-	} else {
+    } else if (platformName.indexOf("Windows") > -1) {
+        return 'interfaces/default/images/platforms/win8.png';
+    } else if (platformName.indexOf("Windows phone") > -1) {
+        return 'interfaces/default/images/platforms/wp.png';
+    } else {
         return 'interfaces/default/images/platforms/default.png';
     }
 }

--- a/data/interfaces/default/js/tables/history_table.js
+++ b/data/interfaces/default/js/tables/history_table.js
@@ -100,7 +100,18 @@ history_table_options = {
         },
         {
             "targets": [4],
-            "data":"player",
+            "data":"platform",
+            "createdCell": function (td, cellData, rowData, row, col) {
+                if (cellData !== '') {
+                    $(td).html(cellData);
+                }
+            },
+            "width": "8%",
+            "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
+        },
+        {
+            "targets": [5],
+            "data": "player",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
                     var transcode_dec = '';
@@ -114,11 +125,11 @@ history_table_options = {
                     $(td).html('<div><a href="#" data-target="#info-modal" data-toggle="modal"><div style="float: left;">' + transcode_dec + '&nbsp;' + cellData + '</div></a></div>');
                 }
             },
-            "width": "15%",
+            "width": "12%",
             "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
         },
         {
-            "targets": [5],
+            "targets": [6],
             "data":"full_title",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -145,7 +156,7 @@ history_table_options = {
             "width": "35%"
         },
         {
-            "targets": [6],
+            "targets": [7],
             "data":"started",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData === null) {
@@ -159,7 +170,7 @@ history_table_options = {
             "className": "no-wrap hidden-sm hidden-xs"
         },
         {
-            "targets": [7],
+            "targets": [8],
             "data":"paused_counter",
             "render": function (data, type, full) {
                 if (data !== null) {
@@ -173,7 +184,7 @@ history_table_options = {
             "className": "no-wrap hidden-md hidden-sm hidden-xs"
         },
         {
-            "targets": [8],
+            "targets": [9],
             "data":"stopped",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData === null) {
@@ -187,7 +198,7 @@ history_table_options = {
             "className": "no-wrap hidden-sm hidden-xs"
         },
         {
-            "targets": [9],
+            "targets": [10],
             "data":"duration",
             "render": function (data, type, full) {
                 if (data !== null) {
@@ -201,7 +212,7 @@ history_table_options = {
             "className": "no-wrap hidden-xs"
         },
         {
-            "targets": [10],
+            "targets": [11],
             "data": "watched_status",
             "render": function (data, type, full) {
                 if (data == 1) {
@@ -462,6 +473,7 @@ function childTableFormat(rowData) {
                 '<th align="left" id="friendly_name">User</th>' +
                 '<th align="left" id="ip_address">IP Address</th>' +
                 '<th align="left" id="platform">Platform</th>' +
+                '<th align="left" id="platform">Player</th>' +
                 '<th align="left" id="title">Title</th>' +
                 '<th align="left" id="started">Started</th>' +
                 '<th align="left" id="paused_counter">Paused</th>' +

--- a/data/interfaces/default/js/tables/sync_table.js
+++ b/data/interfaces/default/js/tables/sync_table.js
@@ -67,13 +67,13 @@ sync_table_options = {
         },
         {
             "targets": [4],
-            "data": "device_name",
-            "className": "no-wrap hidden-xs"
+            "data": "platform",
+            "className": "no-wrap hidden-sm hidden-xs"
         },
         {
             "targets": [5],
-            "data": "platform",
-            "className": "no-wrap hidden-sm hidden-xs"
+            "data": "device_name",
+            "className": "no-wrap hidden-xs"
         },
         {
             "targets": [6],

--- a/data/interfaces/default/js/tables/user_ips.js
+++ b/data/interfaces/default/js/tables/user_ips.js
@@ -49,7 +49,18 @@ user_ip_table_options = {
         },
         {
             "targets": [2],
-            "data":"platform",
+            "data": "platform",
+            "createdCell": function (td, cellData, rowData, row, col) {
+                if (cellData !== '') {
+                    $(td).html(cellData);
+                }
+            },
+            "width": "15%",
+            "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
+        },
+        {
+            "targets": [3],
+            "data":"player",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData) {
                     var transcode_dec = '';
@@ -69,7 +80,7 @@ user_ip_table_options = {
             "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
         },
         {
-            "targets": [3],
+            "targets": [4],
             "data":"last_watched",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -94,10 +105,11 @@ user_ip_table_options = {
                     }
                 }
             },
+            "width": "30%",
             "className": "hidden-sm hidden-xs"
         },
         {
-            "targets": [4],
+            "targets": [5],
             "data":"play_count",
             "searchable": false,
             "width": "10%"

--- a/data/interfaces/default/js/tables/users.js
+++ b/data/interfaces/default/js/tables/users.js
@@ -64,7 +64,7 @@ users_list_table_options = {
                     $(td).html(cellData);
                 }
             },
-            "width": "12%",
+            "width": "10%",
             "className": "edit-user-control no-wrap"
         },
         {
@@ -78,7 +78,7 @@ users_list_table_options = {
                 }
             },
             "searchable": false,
-            "width": "12%",
+            "width": "10%",
             "className": "no-wrap hidden-xs"
         },
         {
@@ -99,12 +99,25 @@ users_list_table_options = {
                     $(td).html('n/a');
                 }
             },
-            "width": "12%",
+            "width": "10%",
             "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control-ip"
         },
         {
             "targets": [5],
-            "data":"platform",
+            "data": "platform",
+            "createdCell": function (td, cellData, rowData, row, col) {
+                if (cellData !== '') {
+                    $(td).html(cellData);
+                } else {
+                    $(td).html('n/a');
+                }
+            },
+            "width": "10%",
+            "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
+        },
+        {
+            "targets": [6],
+            "data":"player",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData) {
                     var transcode_dec = '';
@@ -120,11 +133,11 @@ users_list_table_options = {
                     $(td).html('n/a');
                 }
             },
-            "width": "12%",
+            "width": "15%",
             "className": "no-wrap hidden-md hidden-sm hidden-xs modal-control"
         },
         {
-            "targets": [6],
+            "targets": [7],
             "data":"last_watched",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -153,7 +166,7 @@ users_list_table_options = {
             "className": "hidden-sm hidden-xs"
         },
         {
-            "targets": [7],
+            "targets": [8],
             "data": "plays",
             "searchable": false,
             "width": "10%"

--- a/data/interfaces/default/library_stats.html
+++ b/data/interfaces/default/library_stats.html
@@ -37,7 +37,13 @@ DOCUMENTATION :: END
         <li>
             <div class="home-platforms-instance-info">
                 <div class="home-platforms-instance-name">
+                    % if library['type'] != 'photo':
+                    <h4>
+                        <a href="info?item_id=${library['type']}" title="${library['rows']['title']}">${library['rows']['title']}</a>
+                    </h4>
+                    % else:
                     <h4>${library['rows']['title']}</h4>
+                    % endif
                 </div>
                 <div class="home-platforms-instance-playcount">
                     <h5>${library['rows']['count_type']}</h5>

--- a/data/interfaces/default/sync.html
+++ b/data/interfaces/default/sync.html
@@ -29,8 +29,8 @@
                 <th align='left' id="username">Username</th>
                 <th align='left' id="title">Title</th>
                 <th align='left' id="type">Type</th>
-                <th align='left' id="device">Device</th>
                 <th align='left' id="platform">Platform</th>
+                <th align='left' id="device">Device</th>
                 <th align='left' id="size">Total Size</th>
                 <th align='left' id="items">Total Items</th>
                 <th align='left' id="converted">Converted</th>

--- a/data/interfaces/default/user.html
+++ b/data/interfaces/default/user.html
@@ -85,11 +85,11 @@ from plexpy import helpers
                 <div class="col-md-12">
                     <div class="table-card-header">
                         <div class="header-bar">
-                            <span><i class="fa fa-television"></i> Platform Stats</span>
+                            <span><i class="fa fa-television"></i> Player Stats</span>
                         </div>
                     </div>
                     <div class="table-card-back">
-                        <div id="user-platform-stats" class="user-platforms">
+                        <div id="user-player-stats" class="user-player">
                             <div class='muted'><i class="fa fa-refresh fa-spin"></i> Loading data...</div>
                             <br>
                         </div>
@@ -133,6 +133,7 @@ from plexpy import helpers
                                 <th align="left">Last Seen</th>
                                 <th align="left">IP Address</th>
                                 <th align="left">Last Platform</th>
+                                <th align="left">Last Player</th>
                                 <th align="left">Last Watched</th>
                                 <th align="left">Play Count</th>
                             </tr>
@@ -170,6 +171,7 @@ from plexpy import helpers
                                 <th align='left' id="friendly_name">User</th>
                                 <th align='left' id="ip_address">IP Address</th>
                                 <th align='left' id="platform">Platform</th>
+                                <th align='left' id="player">Player</th>
                                 <th align='left' id="title">Title</th>
                                 <th align='left' id="started">Started</th>
                                 <th align='left' id="paused_counter">Paused</th>
@@ -207,8 +209,8 @@ from plexpy import helpers
                                 <th align='left' id="username">Username</th>
                                 <th align='left' id="sync_title">Title</th>
                                 <th align='left' id="type">Type</th>
-                                <th align='left' id="device">Device</th>
                                 <th align='left' id="sync_platform">Platform</th>
+                                <th align='left' id="device">Device</th>
                                 <th align='left' id="size">Total Size</th>
                                 <th align='left' id="items">Total Items</th>
                                 <th align='left' id="converted">Converted</th>
@@ -309,11 +311,11 @@ from plexpy import helpers
 
         // Populate platform stats
         $.ajax({
-            url: 'get_user_platform_stats',
+            url: 'get_user_player_stats',
             async: true,
             data: { user_id: user_id, user: '${data['username']}' },
             complete: function(xhr, status) {
-                $("#user-platform-stats").html(xhr.responseText);
+                $("#user-player-stats").html(xhr.responseText);
             }
         });
 
@@ -332,7 +334,7 @@ from plexpy import helpers
             history_table = $('#history_table').DataTable(history_table_options);
             history_table.column(2).visible(false);
 
-            var colvis = new $.fn.dataTable.ColVis(history_table, { buttonText: '<i class="fa fa-columns"></i> Select columns', buttonClass: 'btn btn-dark', exclude: [0, 10] });
+            var colvis = new $.fn.dataTable.ColVis(history_table, { buttonText: '<i class="fa fa-columns"></i> Select columns', buttonClass: 'btn btn-dark', exclude: [0, 11] });
             $(colvis.button()).appendTo('#button-bar-history');
             
             clearSearchButton('history_table', history_table);

--- a/data/interfaces/default/user_player_stats.html
+++ b/data/interfaces/default/user_player_stats.html
@@ -11,8 +11,9 @@ data[array_index] :: Usable parameters
 
 == Global keys ==
 result_id               Returns a unique identifier for the result.
-platform_name           Returns the name of the platform.
-total_plays             Returns the play count for the platform.
+player_name             Returns the name of the player.
+platform_type           Returns the name of the platform
+total_plays             Returns the play count for the player.
 
 DOCUMENTATION :: END
 </%doc>
@@ -20,13 +21,13 @@ DOCUMENTATION :: END
 % if data != None:
 % for a in data:
 <ul class="list-unstyled">
-    <div class="user-platforms-instance">
+    <div class="user-player-instance">
         <li>
-            <span id="user-platform-image-${a['result_id']}"></span>
-            <div class="user-platforms-instance-name">
-                ${a['platform_name']}
+            <span id="user-player-image-${a['result_id']}"></span>
+            <div class="user-player-instance-name">
+                ${a['player_name']}
             </div>
-            <div class="user-platforms-instance-playcount">
+            <div class="user-player-instance-playcount">
                 <h3>${a['total_plays']}</h3>
                 <p> plays</p>
             </div>
@@ -34,7 +35,7 @@ DOCUMENTATION :: END
     </div>
 </ul>
 <script>
-    $("#user-platform-image-${a['result_id']}").html("<div class='user-platforms-instance-box' style='background-image: url(" + getPlatformImagePath('${a['platform_type']}') + ");'>");
+    $("#user-player-image-${a['result_id']}").html("<div class='user-player-instance-box' style='background-image: url(" + getPlatformImagePath('${a['platform_type']}') + ");'>");
 </script>
 % endfor
 % else:

--- a/data/interfaces/default/users.html
+++ b/data/interfaces/default/users.html
@@ -29,6 +29,7 @@
                 <th align="left" id="last_seen">Last Seen</th>
                 <th align="left" id="last_known_ip">Last Known IP</th>
                 <th align="left" id="last_platform">Last Platform</th>
+                <th align="left" id="last_player">Last Player</th>
                 <th align="left" id="last_watched">Last Watched</th>
                 <th align="left" id="total_plays">Total Plays</th>
             </tr>

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -42,6 +42,7 @@ class DataFactory(object):
                    'session_history.user_id',
                    'session_history.user',
                    '(CASE WHEN users.friendly_name IS NULL THEN user ELSE users.friendly_name END) as friendly_name',
+                   'platform',
                    'player',
                    'ip_address',
                    'session_history_metadata.media_type',
@@ -104,6 +105,12 @@ class DataFactory(object):
             else:
                 watched_status = 0
 
+            # Rename Mystery platform names
+            platform_names = {'Mystery 3': 'Playstation 3',
+                              'Mystery 4': 'Playstation 4',
+                              'Mystery 5': 'Xbox 360'}
+            platform = platform_names.get(item["platform"], item["platform"])
+
             row = {"reference_id": item["reference_id"],
                    "id": item["id"],
                    "date": item["date"],
@@ -114,6 +121,7 @@ class DataFactory(object):
                    "user_id": item["user_id"],
                    "user": item["user"],
                    "friendly_name": item["friendly_name"],
+                   "platform": platform,
                    "player": item["player"],
                    "ip_address": item["ip_address"],
                    "media_type": item["media_type"],

--- a/plexpy/users.py
+++ b/plexpy/users.py
@@ -32,7 +32,8 @@ class Users(object):
                    'MAX(session_history.started) as last_seen',
                    'session_history.ip_address as ip_address',
                    'COUNT(session_history.id) as plays',
-                   'session_history.player as platform',
+                   'session_history.platform as platform',
+                   'session_history.player as player',
                    'session_history_metadata.full_title as last_watched',
                    'session_history_metadata.thumb',
                    'session_history_metadata.parent_thumb',
@@ -83,12 +84,19 @@ class Users(object):
             else:
                 user_thumb = item['user_thumb']
 
+            # Rename Mystery platform names
+            platform_names = {'Mystery 3': 'Playstation 3',
+                              'Mystery 4': 'Playstation 4',
+                              'Mystery 5': 'Xbox 360'}
+            platform = platform_names.get(item["platform"], item["platform"])
+
             row = {"id": item['id'],
                    "plays": item['plays'],
                    "last_seen": item['last_seen'],
                    "friendly_name": item['friendly_name'],
                    "ip_address": item['ip_address'],
-                   "platform": item['platform'],
+                   "platform": platform,
+                   "player": item['player'],
                    "last_watched": item['last_watched'],
                    "thumb": thumb,
                    "media_type": item['media_type'],
@@ -121,7 +129,8 @@ class Users(object):
                    'session_history.started as last_seen',
                    'session_history.ip_address as ip_address',
                    'COUNT(session_history.id) as play_count',
-                   'session_history.player as platform',
+                   'session_history.platform as platform',
+                   'session_history.player as player',
                    'session_history_metadata.full_title as last_watched',
                    'session_history_metadata.thumb',
                    'session_history_metadata.parent_thumb',
@@ -169,11 +178,18 @@ class Users(object):
             else:
                 thumb = item["thumb"]
 
+            # Rename Mystery platform names
+            platform_names = {'Mystery 3': 'Playstation 3',
+                              'Mystery 4': 'Playstation 4',
+                              'Mystery 5': 'Xbox 360'}
+            platform = platform_names.get(item["platform"], item["platform"])
+
             row = {"id": item['id'],
                    "last_seen": item['last_seen'],
                    "ip_address": item['ip_address'],
                    "play_count": item['play_count'],
-                   "platform": item['platform'],
+                   "platform": platform,
+                   "player": item['player'],
                    "last_watched": item['last_watched'],
                    "thumb": thumb,
                    "media_type": item['media_type'],
@@ -490,10 +506,10 @@ class Users(object):
 
         return user_watch_time_stats
 
-    def get_user_platform_stats(self, user=None, user_id=None):
+    def get_user_player_stats(self, user=None, user_id=None):
         monitor_db = database.MonitorDatabase()
 
-        platform_stats = []
+        player_stats = []
         result_id = 0
 
         try:
@@ -522,12 +538,12 @@ class Users(object):
                               'Mystery 5': 'Xbox 360'}
             platform_type = platform_names.get(item[2], item[2])
 
-            row = {'platform_name': item[0],
+            row = {'player_name': item[0],
                    'platform_type': platform_type,
                    'total_plays': item[1],
                    'result_id': result_id
                    }
-            platform_stats.append(row)
+            player_stats.append(row)
             result_id += 1
 
-        return platform_stats
+        return player_stats

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -813,17 +813,17 @@ class WebInterface(object):
             return serve_template(templatename="user_watch_time_stats.html", data=None, title="Watch Stats")
 
     @cherrypy.expose
-    def get_user_platform_stats(self, user=None, user_id=None, **kwargs):
+    def get_user_player_stats(self, user=None, user_id=None, **kwargs):
 
         user_data = users.Users()
-        result = user_data.get_user_platform_stats(user_id=user_id, user=user)
+        result = user_data.get_user_player_stats(user_id=user_id, user=user)
 
         if result:
-            return serve_template(templatename="user_platform_stats.html", data=result,
-                                  title="Platform Stats")
+            return serve_template(templatename="user_player_stats.html", data=result,
+                                  title="Player Stats")
         else:
             logger.warn('Unable to retrieve data.')
-            return serve_template(templatename="user_platform_stats.html", data=None, title="Platform Stats")
+            return serve_template(templatename="user_player_stats.html", data=None, title="Player Stats")
 
     @cherrypy.expose
     def get_item_children(self, rating_key='', **kwargs):

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -587,6 +587,9 @@ class WebInterface(object):
         if 'reference_id' in kwargs:
             reference_id = kwargs.get('reference_id', "")
             custom_where = [['session_history.reference_id', reference_id]]
+        if 'media_type' in kwargs:
+            media_type = kwargs.get('media_type', "")
+            custom_where = [['session_history_metadata.media_type', media_type]]
 
         data_factory = datafactory.DataFactory()
         history = data_factory.get_history(kwargs=kwargs, custom_where=custom_where, grouping=grouping, watched_percent=watched_percent)
@@ -771,6 +774,12 @@ class WebInterface(object):
         if source == 'history':
             data_factory = datafactory.DataFactory()
             metadata = data_factory.get_metadata_details(row_id=item_id)
+        elif item_id == 'movie':
+            metadata = {'type': 'library', 'library': 'movie', 'media_type': 'movie', 'title': 'Movies'}
+        elif item_id == 'show':
+            metadata = {'type': 'library', 'library': 'show', 'media_type': 'episode', 'title': 'TV Shows'}
+        elif item_id == 'music':
+            metadata = {'type': 'library', 'library': 'music', 'media_type': 'track', 'title': 'Music'}
         else:
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_metadata_details(rating_key=item_id)

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -778,8 +778,8 @@ class WebInterface(object):
             metadata = {'type': 'library', 'library': 'movie', 'media_type': 'movie', 'title': 'Movies'}
         elif item_id == 'show':
             metadata = {'type': 'library', 'library': 'show', 'media_type': 'episode', 'title': 'TV Shows'}
-        elif item_id == 'music':
-            metadata = {'type': 'library', 'library': 'music', 'media_type': 'track', 'title': 'Music'}
+        elif item_id == 'artist':
+            metadata = {'type': 'library', 'library': 'artist', 'media_type': 'track', 'title': 'Music'}
         else:
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_metadata_details(rating_key=item_id)


### PR DESCRIPTION
- Add "Player" to tables
  - Also rename user platforms to user players
  - Fix other platform vs. player ambiguities
- Add top level info pages with history table
  - Reference #219 - not a filter, but achieves the same result.
