### PR TITLE
Feature/telegram channel support

### DIFF
--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -250,7 +250,7 @@ _CONFIG_DEFINITIONS = {
     'REFRESH_USERS_ON_STARTUP': (int, 'Monitoring', 1),
     'TELEGRAM_BOT_TOKEN': (str, 'Telegram', ''),
     'TELEGRAM_ENABLED': (int, 'Telegram', 0),
-    'TELEGRAM_CHAT_ID': (int, 'Telegram', 0),
+    'TELEGRAM_CHAT_ID': (str, 'Telegram', ''),
     'TELEGRAM_ON_PLAY': (int, 'Telegram', 0),
     'TELEGRAM_ON_STOP': (int, 'Telegram', 0),
     'TELEGRAM_ON_PAUSE': (int, 'Telegram', 0),

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1526,7 +1526,7 @@ class TELEGRAM(object):
                          {'label': 'Telegram Chat ID',
                           'value': self.chat_id,
                           'name': 'telegram_chat_id',
-                          'description': 'Your Telegram Chat ID or Group ID. Contact <a href="http://telegram.me/myidbot" target="_blank">@myidbot</a> on Telegram to get an ID.',
+                          'description': 'Your Telegram Chat ID, Group ID, or channel username. Contact <a href="http://telegram.me/myidbot" target="_blank">@myidbot</a> on Telegram to get an ID.',
                           'input_type': 'text'
                           }
                          ]


### PR DESCRIPTION
Telegram has added support for sending to channels, I have updated this so chat_id is a string, and will work with the @channelusername chat_id

Here is the documentation:
https://core.telegram.org/bots/api

Thanks!
