### PR TITLE
Update base.html

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -51,8 +51,11 @@ from plexpy import version
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="home">
+                <a class="navbar-brand hidden-md hidden-xs hidden-sm" href="home">
                     <img alt="PlexPy" src="interfaces/default/images/logo-plexpy@2x.png" height="40">
+                </a>
+                <a class="navbar-brand hidden-lg" href="home">
+                    <img alt="PlexPy" src="interfaces/default/images/icon_ipad.png" height="40">
                 </a>
             </div>
             <div class="collapse navbar-collapse navbar-right" id="navbar-collapse-1">


### PR DESCRIPTION
Current-Activity Header is hidden in Mid and small devices because the logo is too big and it causes Navigation bar to appear on top of the activity header or hides show->episodes navigation.

This way, it will still show full logo on larger display and will show smaller logo on smaller display so information is not hidden.
