### PR TITLE
add .pem cert to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ cache/*
 *.crt
 *.key
 *.csr
+*.pem
 
 # OS generated files #
 ######################


### PR DESCRIPTION
A lot of people generate self-signed certs and use the .pem format...lets make sure those never make it back upstream!
