### PR TITLE
CentOS 6.X startup script

### DIFF
--- a/init-scripts/init.fedora.centos.service
+++ b/init-scripts/init.fedora.centos.service
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:          PlexPy 
+# Required-Start:    $all
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts PlexPy 
+# Description:       starts PlexPy
+### END INIT INFO
+
+# Source function library.
+. /etc/init.d/functions
+
+## Variables
+prog=plexpy
+lockfile=/var/lock/subsys/$prog
+homedir=/opt/plexpy
+datadir=/opt/plexpy
+configfile=/opt/plexpy/config.ini
+pidfile=/var/run/plexpy.pid
+nice=
+# The following line must point to your Python 2.7 install
+python27=/usr/src/Python-2.7.11/python
+##
+
+options=" --daemon --config $configfile --pidfile $pidfile --datadir $datadir --nolaunch --quiet"
+
+start() {
+        # Start daemon.
+        echo -n $"Starting $prog: "
+        daemon --pidfile=$pidfile $nice $python27 $homedir/PlexPy.py $options
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && touch $lockfile
+        return $RETVAL
+}
+
+stop() {
+        echo -n $"Shutting down $prog: "
+        killproc -p $pidfile $python27
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && rm -f $lockfile
+        return $RETVAL
+}
+
+# See how we were called.
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  status)
+        status $prog
+        ;;
+  restart|force-reload)
+        stop
+        start
+        ;;
+  try-restart|condrestart)
+        if status $prog > /dev/null; then
+            stop
+            start
+        fi
+        ;;
+  reload)
+        exit 3
+        ;;
+  *)
+        echo $"Usage: $0 {start|stop|status|restart|try-restart|force-reload}"
+        exit 2
+esac


### PR DESCRIPTION
Init file for CentOS 6.X systems, variables exist for different install directorys. Please note, current version of Python is 2.6 and PlexPy requires 2.7. A variable exists to point to this path.

Since PlexPy is based on Headphones, I just copied the init script for Headphones and changed the paths and added the Python2.7 path
