### PR TITLE
Watched notifications using websockets fix

### DIFF
--- a/data/interfaces/default/welcome.html
+++ b/data/interfaces/default/welcome.html
@@ -378,8 +378,8 @@ from plexpy import common
             var pms_ip = $("#pms_ip").val().trim();
             var pms_port = $("#pms_port").val().trim();
             var pms_identifier = $("#pms_identifier").val();
-            var pms_ssl = $("#pms_ssl").val();
-            var pms_is_remote = $("#pms_is_remote").val();
+            var pms_ssl = $("#pms_ssl").is(':checked') ? 1 : 0;
+            var pms_is_remote = $("#pms_is_remote").is(':checked') ? 1 : 0;
             if ((pms_ip !== '') || (pms_port !== '')) {
                 $("#pms-verify-status").html('<i class="fa fa-refresh fa-spin"></i> Validating server...');
                 $('#pms-verify-status').fadeIn('fast');


### PR DESCRIPTION
Annoyingly I am getting a lot of duplicate watched notifications as it appears the state is not yet written to the db before the next one fires off.

I've tried to address this here (as well as fix a bug on the welcome page).
