### PR TITLE
Add environment option

### DIFF
--- a/PlexPy.py
+++ b/PlexPy.py
@@ -179,6 +179,7 @@ def main():
     # Try to start the server. Will exit here is address is already in use.
     web_config = {
         'http_port': http_port,
+        'http_environment': plexpy.CONFIG.HTTP_ENVIRONMENT,
         'http_host': plexpy.CONFIG.HTTP_HOST,
         'http_root': plexpy.CONFIG.HTTP_ROOT,
         'http_proxy': plexpy.CONFIG.HTTP_PROXY,

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -142,6 +142,7 @@ _CONFIG_DEFINITIONS = {
     'HTTPS_KEY': (str, 'General', ''),
     'HTTPS_DOMAIN': (str, 'General', 'localhost'),
     'HTTPS_IP': (str, 'General', '127.0.0.1'),
+    'HTTP_ENVIRONMENT': (str, 'General', 'production'),
     'HTTP_HOST': (str, 'General', '0.0.0.0'),
     'HTTP_PASSWORD': (str, 'General', ''),
     'HTTP_PORT': (int, 'General', 8181),

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -44,7 +44,7 @@ def initialize(options):
             enable_https = False
 
     options_dict = {
-        'environment' :options['http_environment'],
+        'environment': options['http_environment'],
         'server.socket_port': options['http_port'],
         'server.socket_host': options['http_host'],
         'server.thread_pool': 10,

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -44,6 +44,7 @@ def initialize(options):
             enable_https = False
 
     options_dict = {
+        'environment' :options['http_environment'],
         'server.socket_port': options['http_port'],
         'server.socket_host': options['http_host'],
         'server.thread_pool': 10,


### PR DESCRIPTION
Add http_environment option allowing user to set cherrypy environment from plexpy config.ini. Default for new option is set to '**production**'.

CherryPy Built-in environment options: production, staging, embedded, test-suite
