### PR TITLE
Add CherryPy Environment Option

### DIFF
--- a/PlexPy.py
+++ b/PlexPy.py
@@ -181,6 +181,7 @@ def main():
         'http_port': http_port,
         'http_host': plexpy.CONFIG.HTTP_HOST,
         'http_root': plexpy.CONFIG.HTTP_ROOT,
+        'http_environment': plexpy.CONFIG.HTTP_ENVIRONMENT,
         'http_proxy': plexpy.CONFIG.HTTP_PROXY,
         'enable_https': plexpy.CONFIG.ENABLE_HTTPS,
         'https_cert': plexpy.CONFIG.HTTPS_CERT,

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -142,6 +142,7 @@ _CONFIG_DEFINITIONS = {
     'HTTPS_KEY': (str, 'General', ''),
     'HTTPS_DOMAIN': (str, 'General', 'localhost'),
     'HTTPS_IP': (str, 'General', '127.0.0.1'),
+    'HTTP_ENVIRONMENT': (str, 'General', 'production'),
     'HTTP_HOST': (str, 'General', '0.0.0.0'),
     'HTTP_PASSWORD': (str, 'General', ''),
     'HTTP_PORT': (int, 'General', 8181),

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -46,6 +46,7 @@ def initialize(options):
     options_dict = {
         'server.socket_port': options['http_port'],
         'server.socket_host': options['http_host'],
+        'environment': options['http_environment'],
         'server.thread_pool': 10,
         'tools.encode.on': True,
         'tools.encode.encoding': 'utf-8',


### PR DESCRIPTION
Add `http_environment` option allowing user to set CherryPy environment from PlexPy `config.ini`. Default for new option is set to `production`.

CherryPy Built-in environment options: `production`, `staging`, `embedded`, `test_suite`

CherryPy's environment option allows for groups of default configuration settings to be set via a single option. The following shows the option sets for each of the default environments.
##### Source from _cpconfig.py

``` python
Config.environments = environments = {
    "staging": {
        'engine.autoreload_on': False,
        'checker.on': False,
        'tools.log_headers.on': False,
        'request.show_tracebacks': False,
        'request.show_mismatched_params': False,
        },
    "production": {
        'engine.autoreload_on': False,
        'checker.on': False,
        'tools.log_headers.on': False,
        'request.show_tracebacks': False,
        'request.show_mismatched_params': False,
        'log.screen': False,
        },
    "embedded": {
        # For use with CherryPy embedded in another deployment stack.
        'engine.autoreload_on': False,
        'checker.on': False,
        'tools.log_headers.on': False,
        'request.show_tracebacks': False,
        'request.show_mismatched_params': False,
        'log.screen': False,
        'engine.SIGHUP': None,
        'engine.SIGTERM': None,
        },
    "test_suite": {
        'engine.autoreload_on': False,
        'checker.on': False,
        'tools.log_headers.on': False,
        'request.show_tracebacks': True,
        'request.show_mismatched_params': True,
        'log.screen': False,
        },
    }
```
