### PR TITLE
Enable PlexPy dev environment

### DIFF
--- a/PlexPy.py
+++ b/PlexPy.py
@@ -82,10 +82,13 @@ def main():
     parser.add_argument(
         '-p', '--port', type=int, help='Force PlexPy to run on a specified port')
     parser.add_argument(
+        '--dev', action='store_true', help='Start PlexPy in the development environment')
+    parser.add_argument(
         '--datadir', help='Specify a directory where to store your data files')
-    parser.add_argument('--config', help='Specify a config file to use')
-    parser.add_argument('--nolaunch', action='store_true',
-                        help='Prevent browser from launching on startup')
+    parser.add_argument(
+        '--config', help='Specify a config file to use')
+    parser.add_argument(
+        '--nolaunch', action='store_true', help='Prevent browser from launching on startup')
     parser.add_argument(
         '--pidfile', help='Create a pid file (only relevant when running as a daemon)')
 
@@ -99,6 +102,10 @@ def main():
     # Do an intial setup of the logger.
     logger.initLogger(console=not plexpy.QUIET, log_dir=False,
                       verbose=plexpy.VERBOSE)
+
+    if args.dev:
+        plexpy.DEV = True
+        logger.debug(u"PlexPy is running in the dev environment.")
 
     if args.daemon:
         if sys.platform == 'win32':
@@ -164,6 +171,19 @@ def main():
     # Read config and start logging
     plexpy.initialize(config_file)
 
+    # Start the background threads
+    plexpy.start()
+
+    # Open connection for websocket
+    if plexpy.CONFIG.MONITORING_USE_WEBSOCKET:
+        try:
+            web_socket.start_thread()
+        except:
+            logger.warn(u"Websocket :: Unable to open connection.")
+            # Fallback to polling
+            plexpy.POLLING_FAILOVER = True
+            plexpy.initialize_scheduler()
+
     # Force the http port if neccessary
     if args.port:
         http_port = args.port
@@ -196,21 +216,8 @@ def main():
     }
     webstart.initialize(web_config)
 
-    # Start the background threads
-    plexpy.start()
-
-    # Open connection for websocket
-    if plexpy.CONFIG.MONITORING_USE_WEBSOCKET:
-        try:
-            web_socket.start_thread()
-        except:
-            logger.warn(u"Websocket :: Unable to open connection.")
-            # Fallback to polling
-            plexpy.POLLING_FAILOVER = True
-            plexpy.initialize_scheduler()
-
     # Open webbrowser
-    if plexpy.CONFIG.LAUNCH_BROWSER and not args.nolaunch:
+    if plexpy.CONFIG.LAUNCH_BROWSER and not args.nolaunch and not plexpy.DEV:
         plexpy.launch_browser(plexpy.CONFIG.HTTP_HOST, http_port,
                               plexpy.CONFIG.HTTP_ROOT)
 

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -74,6 +74,8 @@ UMASK = None
 
 POLLING_FAILOVER = False
 
+DEV = False
+
 
 def initialize(config_file):
     with INIT_LOCK:

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -449,7 +449,9 @@ class Config(object):
         for key in _CONFIG_DEFINITIONS.keys():
             self.check_setting(key)
         self._upgrade()
-        self._blacklist()
+
+        if not plexpy.DEV:
+            self._blacklist()
 
     def _blacklist(self):
         """ Add tokens and passwords to blacklisted words in logger """
@@ -520,7 +522,8 @@ class Config(object):
         except IOError as e:
             plexpy.logger.error("Error writing configuration file: %s", e)
 
-        self._blacklist()
+        if not plexpy.DEV:
+            self._blacklist()
 
     def __getattr__(self, name):
         """

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -51,8 +51,6 @@ def initialize(options):
         'tools.encode.on': True,
         'tools.encode.encoding': 'utf-8',
         'tools.decode.on': True,
-        'log.screen': False,
-        'engine.autoreload.on': False,
     }
 
     if enable_https:
@@ -61,6 +59,10 @@ def initialize(options):
         protocol = "https"
     else:
         protocol = "http"
+
+    if plexpy.DEV:
+        options_dict['environment'] = "test_suite"
+        options_dict['engine.autoreload.on'] = True
 
     logger.info("Starting PlexPy web server on %s://%s:%d/", protocol,
                 options['http_host'], options['http_port'])
@@ -120,7 +122,12 @@ def initialize(options):
 
     try:
         cherrypy.process.servers.check_port(str(options['http_host']), options['http_port'])
-        cherrypy.server.start()
+        if not plexpy.DEV:
+            cherrypy.server.start()
+        else:
+            cherrypy.engine.signals.subscribe()
+            cherrypy.engine.start()
+            cherrypy.engine.block()
     except IOError:
         sys.stderr.write('Failed to start on port: %i. Is something else running?\n' % (options['http_port']))
         sys.exit(1)


### PR DESCRIPTION
@Hellowlol #612

Set `plexpy_dev_env = 1` in the config file for the dev environment

While in the dev environment:
- Web browser does not launch
- Tracebacks shown in the web browser
- Shutdown/restart/update signals from the WebUI don't work (who's using these during dev anyways?)
  - Signals handled by cherrypy (Ctrl+C to exit)
- Passwords/tokens/ids/etc are not blacklisted in the logger
- Cherrypy engine autoreloads on code change
