### PR TITLE
Fix unicode logging with 1252 encoded locale on Windows

### DIFF
--- a/plexpy/logger.py
+++ b/plexpy/logger.py
@@ -183,7 +183,7 @@ def initLogger(console=False, log_dir=False, verbose=False):
     if log_dir:
         filename = os.path.join(log_dir, FILENAME)
 
-        file_formatter = logging.Formatter('%(asctime)s - %(levelname)-7s :: %(threadName)s : %(message)s', '%d-%b-%Y %H:%M:%S')
+        file_formatter = logging.Formatter('%(asctime)s - %(levelname)-7s :: %(threadName)s : %(message)s', '%d-%m-%Y %H:%M:%S')
         file_handler = handlers.RotatingFileHandler(filename, maxBytes=MAX_SIZE, backupCount=MAX_FILES)
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(file_formatter)
@@ -193,7 +193,7 @@ def initLogger(console=False, log_dir=False, verbose=False):
 
     # Setup console logger
     if console:
-        console_formatter = logging.Formatter('%(asctime)s - %(levelname)s :: %(threadName)s : %(message)s', '%d-%b-%Y %H:%M:%S')
+        console_formatter = logging.Formatter('%(asctime)s - %(levelname)s :: %(threadName)s : %(message)s', '%d-%m-%Y %H:%M:%S')
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(console_formatter)
         console_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
On my system (Windows, Swiss-German locale) I get loads of UnicodeDecodeErrors instead of log messages.

Apparently, my locale makes "%b" evaluate to "Mär". Combining this with unicode log messages makes the logger throw an exception during formatting. A simple workaround that I've found is to replace the abbreviation with a numeric month representation.

Changing the format strings to be unicode themselves does not help, unfortunately. I suspect it's connected to Windows' locale encoding being Windows-1252.

Resubmitted from #629 
