### PR TITLE
Allow formatting of IFTTT event key with action name

### DIFF
--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -436,7 +436,7 @@ def get_notification_agent_config(agent_id):
         return []
 
 
-def send_notification(agent_id, subject, body, **kwargs):
+def send_notification(agent_id, subject, body, notify_action, **kwargs):
     if str(agent_id).isdigit():
         agent_id = int(agent_id)
 
@@ -478,7 +478,7 @@ def send_notification(agent_id, subject, body, **kwargs):
             tweet.notify(subject=subject, message=body)
         elif agent_id == 12:
             iftttClient = IFTTT()
-            iftttClient.notify(subject=subject, message=body)
+            iftttClient.notify(subject=subject, message=body, action=notify_action)
         elif agent_id == 13:
             telegramClient = TELEGRAM()
             telegramClient.notify(message=body, event=subject)
@@ -1604,10 +1604,11 @@ class IFTTT(object):
         self.apikey = plexpy.CONFIG.IFTTT_KEY
         self.event = plexpy.CONFIG.IFTTT_EVENT
 
-    def notify(self, message, subject):
+    def notify(self, message, subject, action):
         if not message or not subject:
             return
 
+        event = unicode(self.event).format(action=action)
         http_handler = HTTPSConnection("maker.ifttt.com")
 
         data = {'value1': subject.encode("utf-8"),
@@ -1616,7 +1617,7 @@ class IFTTT(object):
         # logger.debug(u"Ifttt SENDING: %s" % json.dumps(data))
 
         http_handler.request("POST",
-                             "/trigger/%s/with/key/%s" % (self.event, self.apikey),
+                             "/trigger/%s/with/key/%s" % (event, self.apikey),
                              headers={'Content-type': "application/json"},
                              body=json.dumps(data))
         response = http_handler.getresponse()
@@ -1649,7 +1650,9 @@ class IFTTT(object):
                          {'label': 'Ifttt Event',
                           'value': self.event,
                           'name': 'ifttt_event',
-                          'description': 'The Ifttt maker event to fire. The notification subject and body will be sent'
+                          'description': 'The Ifttt maker event to fire. You can include'
+                                         ' the {action} to be substituted with the action name.'
+                                         ' The notification subject and body will be sent'
                                          ' as value1 and value2 respectively.',
                           'input_type': 'text'
                           }

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1456,7 +1456,7 @@ class WebInterface(object):
 
             if this_agent:
                 logger.debug(u"Sending test %s notification." % this_agent['name'])
-                notifiers.send_notification(this_agent['id'], subject, body, **kwargs)
+                notifiers.send_notification(this_agent['id'], subject, body, 'test', **kwargs)
                 return "Notification sent."
             else:
                 logger.debug(u"Unable to send test notification, invalid notification agent ID %s." % agent_id)


### PR DESCRIPTION
The existing IFTTT implementation is very limiting as to what you do with the service because all events emitted use the same name and IFTTT does offer any mechanism to filter actions based on the subject. This change allows for enriching the event name sent to Maker thus allowing better control of actions to be carried out. ie. Turn lights off when playing a movie and turn them back on when stopped. 

To avoid breaking existing implementations the feature is op-in by including a `{action}` placeholder in the event name. ie. `plexpy_{action}`.
