### PR TITLE
Reflect path suggested in installation guide

### DIFF
--- a/init-scripts/init.freebsd
+++ b/init-scripts/init.freebsd
@@ -14,7 +14,7 @@
 #           default. Do not sets it as empty or it will run
 #           as root.
 # plexpy_dir:   Directory where PlexPy lives.
-#           Default: /usr/local/plexpy
+#           Default: /usr/local/share/plexpy
 # plexpy_chdir:  Change to this directory before running PlexPy.
 #     Default is same as plexpy_dir.
 # plexpy_pid:  The name of the pidfile to create.
@@ -30,7 +30,7 @@ load_rc_config ${name}
 
 : ${plexpy_enable:="NO"}
 : ${plexpy_user:="_sabnzbd"}
-: ${plexpy_dir:="/usr/local/plexpy"}
+: ${plexpy_dir:="/usr/local/share/plexpy"}
 : ${plexpy_chdir:="${plexpy_dir}"}
 : ${plexpy_pid:="${plexpy_dir}/plexpy.pid"}
 : ${plexpy_flags:=""}


### PR DESCRIPTION
The installation guide suggests the install path as "/usr/local/share" for FreeBSD. This is also stated in the daemon guide but the daemon file to be copied does not reflect that suggested path. This fixes that descrepency (in tandem with the changes I just made to the wiki page).
