### PR TITLE
Quick Fix for iPhone 6/7 Plus

### DIFF
--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -2662,7 +2662,7 @@ a .home-platforms-list-cover-face:hover
 
 @media only screen 
   and (min-device-width: 300px) 
-  and (max-device-width: 400px) {
+  and (max-device-width: 450px) {
     .home-platforms-instance {
         width: calc(100% - 20px);
     }


### PR DESCRIPTION
I changed the max-device-width from 400px to 450px so it adjusts to the iPhone 6/7 Plus screen and doesn't leave a gap on the right of the screen.

This should now be in the correct branch (sorry about that!)
