### PR TITLE
Human file size for media info table

### DIFF
--- a/data/interfaces/default/js/tables/media_info_table.js
+++ b/data/interfaces/default/js/tables/media_info_table.js
@@ -280,8 +280,8 @@ media_info_table_options = {
         }
 
         $("#media_info_table-SID-" + section_id + "_info").append('<span class="hidden-md hidden-sm hidden-xs"> with a total file size of ' +
-            Math.round(settings.json.filtered_file_size / Math.pow(1024, 3)).toString() + ' GiB' +
-            ' (filtered from ' + Math.round(settings.json.total_file_size / Math.pow(1024, 3)).toString() + ' GiB)</span>');
+            humanFileSize(settings.json.filtered_file_size) +
+            ' (filtered from ' + humanFileSize(settings.json.total_file_size) + ')</span>');
     },
     "preDrawCallback": function(settings) {
         var msg = "<i class='fa fa-refresh fa-spin'></i>&nbspFetching rows...";
@@ -484,4 +484,21 @@ function createChildTableMedia(row, rowData) {
             createChildTableMedia(row, rowData);
         }
     });
+}
+
+// Taken from http://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable#answer-14919494
+function humanFileSize(bytes, si) {
+    var thresh = si ? 1000 : 1024;
+    if(Math.abs(bytes) < thresh) {
+        return bytes + ' B';
+    }
+    var units = si
+        ? ['kB','MB','GB','TB','PB','EB','ZB','YB']
+        : ['KiB','MiB','GiB','TiB','PiB','EiB','ZiB','YiB'];
+    var u = -1;
+    do {
+        bytes /= thresh;
+        ++u;
+    } while(Math.abs(bytes) >= thresh && u < units.length - 1);
+    return bytes.toFixed(1)+'&nbsp;'+units[u];
 }


### PR DESCRIPTION
I added a function to generate a human readable file size for the media info table. So it's not locked to GiB. Useful if you have a large library and want it in TiB instead.
