### PR TITLE
Allow certificates to be chained certificates

### DIFF
--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -59,6 +59,7 @@ def initialize(options):
 
     if enable_https:
         options_dict['server.ssl_certificate'] = https_cert
+        options_dict['server.ssl_certificate_chain'] = https_cert
         options_dict['server.ssl_private_key'] = https_key
         protocol = "https"
     else:


### PR DESCRIPTION
There are issues with SSL cert error on Android when using certs from certain issuers (e.g. letsencrypt). Allowing the cert to be a chained cert solves this. Doesn't affect the use of SSL certs in any other way.