### PR TITLE
Pep8 cleanups, small (really small) bug fixes, cleanup imports

### DIFF
--- a/plexpy/activity_handler.py
+++ b/plexpy/activity_handler.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,20 +14,18 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import threading
 import time
 
-import plexpy
 import activity_processor
-import datafactory
 import helpers
 import logger
 import notification_handler
-import notifiers
+import plexpy
 import pmsconnect
 
 
 RECENTLY_ADDED_QUEUE = {}
+
 
 class ActivityHandler(object):
 
@@ -177,8 +176,9 @@ class ActivityHandler(object):
                              (self.get_session_key(), buffer_last_triggered))
                 time_since_last_trigger = int(time.time()) - int(buffer_last_triggered)
 
-            if plexpy.CONFIG.BUFFER_THRESHOLD > 0 and (current_buffer_count >= plexpy.CONFIG.BUFFER_THRESHOLD and \
-                time_since_last_trigger == 0 or time_since_last_trigger >= plexpy.CONFIG.BUFFER_WAIT):
+            if plexpy.CONFIG.BUFFER_THRESHOLD > 0 and (current_buffer_count >= plexpy.CONFIG.BUFFER_THRESHOLD and
+                                                       time_since_last_trigger == 0 or
+                                                       time_since_last_trigger >= plexpy.CONFIG.BUFFER_WAIT):
                 ap.set_session_buffer_trigger_time(session_key=self.get_session_key())
 
                 plexpy.NOTIFY_QUEUE.put({'stream_data': db_session, 'notify_action': 'on_buffer'})
@@ -227,13 +227,14 @@ class ActivityHandler(object):
                     progress_percent = helpers.get_percent(db_session['view_offset'], db_session['duration'])
                     notify_states = notification_handler.get_notify_state(session=db_session)
                     if progress_percent >= plexpy.CONFIG.NOTIFY_WATCHED_PERCENT \
-                        and not any(d['notify_action'] == 'on_watched' for d in notify_states):
+                            and not any(d['notify_action'] == 'on_watched' for d in notify_states):
                         plexpy.NOTIFY_QUEUE.put({'stream_data': db_session, 'notify_action': 'on_watched'})
 
             else:
                 # We don't have this session in our table yet, start a new one.
                 if this_state != 'buffering':
                     self.on_start()
+
 
 class TimelineHandler(object):
 
@@ -272,7 +273,7 @@ class TimelineHandler(object):
                 data.update(kwargs)
                 plexpy.NOTIFY_QUEUE.put(data)
             else:
-                logger.error(u"PlexPy TimelineHandler :: Unable to retrieve metadata for rating_key %s" \
+                logger.error(u"PlexPy TimelineHandler :: Unable to retrieve metadata for rating_key %s"
                              % str(rating_key))
 
     # This function receives events from our websocket connection
@@ -300,8 +301,8 @@ class TimelineHandler(object):
 
             # Add a new media item to the recently added queue
             if media_type and section_id > 0 and \
-                ((state_type == 0 and metadata_state == 'created') or \
-                (plexpy.CONFIG.NOTIFY_RECENTLY_ADDED_UPGRADE and state_type in (1, 5) and \
+                ((state_type == 0 and metadata_state == 'created') or
+                 (plexpy.CONFIG.NOTIFY_RECENTLY_ADDED_UPGRADE and state_type in (1, 5) and
                  media_state == 'analyzing' and queue_size is None)):
 
                 if media_type in ('episode', 'track'):
@@ -345,7 +346,7 @@ class TimelineHandler(object):
             # A movie, show, or artist is done processing
             elif media_type in ('movie', 'show', 'artist') and section_id > 0 and \
                 state_type == 5 and metadata_state is None and queue_size is None and \
-                rating_key in RECENTLY_ADDED_QUEUE:
+                    rating_key in RECENTLY_ADDED_QUEUE:
                 
                 logger.debug(u"PlexPy TimelineHandler :: Library item '%s' (%s) done processing metadata."
                              % (title, str(rating_key)))
@@ -375,12 +376,11 @@ class TimelineHandler(object):
                 # Remove all keys
                 self.del_keys(rating_key)
 
-
             # An episode or track is done processing (upgrade only)
             elif plexpy.CONFIG.NOTIFY_RECENTLY_ADDED_UPGRADE and \
                 media_type in ('episode', 'track') and section_id > 0 and \
                 state_type == 5 and metadata_state is None and queue_size is None and \
-                rating_key in RECENTLY_ADDED_QUEUE:
+                    rating_key in RECENTLY_ADDED_QUEUE:
                 
                 logger.debug(u"PlexPy TimelineHandler :: Library item '%s' (%s) done processing metadata (upgrade)."
                              % (title, str(rating_key)))

--- a/plexpy/activity_processor.py
+++ b/plexpy/activity_processor.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,18 +14,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import threading
 import time
-import re
 
-import plexpy
 import database
-import datafactory
 import libraries
-import log_reader
 import logger
-import notification_handler
-import notifiers
+import plexpy
 import pmsconnect
 import users
 
@@ -56,7 +51,7 @@ class ActivityProcessor(object):
                       'grandparent_thumb': session['grandparent_thumb'],
                       'year': session['year'],
                       'friendly_name': session['friendly_name'],
-                      #'ip_address': session['ip_address'],
+                      # 'ip_address': session['ip_address'],
                       'player': session['player'],
                       'platform': session['platform'],
                       'parent_rating_key': session['parent_rating_key'],
@@ -237,7 +232,7 @@ class ActivityProcessor(object):
 
                 query = 'UPDATE session_history SET reference_id = ? WHERE id = ? '
                 # If rating_key is the same in the previous session, then set the reference_id to the previous row, else set the reference_id to the new id
-                if  prev_session == new_session == None:
+                if prev_session is None and new_session is None:
                     args = [last_id, last_id]
                 elif prev_session['rating_key'] == new_session['rating_key'] and prev_session['view_offset'] <= new_session['view_offset']:
                     args = [prev_session['reference_id'], new_session['id']]

--- a/plexpy/api2.py
+++ b/plexpy/api2.py
@@ -29,15 +29,15 @@ import traceback
 import cherrypy
 import xmltodict
 
-import plexpy
 import config
 import database
 import logger
+import plexpy
 import plextv
 import pmsconnect
 
 
-class API2:
+class API2(object):
     def __init__(self, **kwargs):
         self._api_valid_methods = self._api_docs().keys()
         self._api_authenticated = False

--- a/plexpy/classes.py
+++ b/plexpy/classes.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -55,11 +56,11 @@ class AuthURLOpener(PlexPyURLopener):
         # if this is the first try then provide a username/password
         if self.numTries == 0:
             self.numTries = 1
-            return (self.username, self.password)
+            return self.username, self.password
 
         # if we've tried before then return blank which cancels the request
         else:
-            return ('', '')
+            return '', ''
 
     # this is pretty much just a hack for convenience
     def openit(self, url):

--- a/plexpy/common.py
+++ b/plexpy/common.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -13,11 +14,11 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-'''
+"""
 Created on Aug 1, 2011
 
 @author: Michael
-'''
+"""
 import platform
 
 import version

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,15 +14,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import arrow
 import os
 import re
 import shutil
+import time
 
+import arrow
 from configobj import ConfigObj
 
-import plexpy
 import logger
+import plexpy
 
 
 def bool_int(value):
@@ -195,13 +197,14 @@ _CONFIG_DEFINITIONS = {
     'GROWL_ON_CONCURRENT': (int, 'Growl', 0),
     'GROWL_ON_NEWDEVICE': (int, 'Growl', 0),
     'HISTORY_TABLE_ACTIVITY': (int, 'General', 1),
-    'HOME_SECTIONS': (list, 'General', ['current_activity','watch_stats','library_stats','recently_added']),
+    'HOME_SECTIONS': (list, 'General', ['current_activity', 'watch_stats', 'library_stats', 'recently_added']),
     'HOME_LIBRARY_CARDS': (list, 'General', ['first_run']),
     'HOME_STATS_LENGTH': (int, 'General', 30),
     'HOME_STATS_TYPE': (int, 'General', 0),
     'HOME_STATS_COUNT': (int, 'General', 5),
-    'HOME_STATS_CARDS': (list, 'General', ['top_movies', 'popular_movies', 'top_tv', 'popular_tv', 'top_music', \
-        'popular_music', 'last_watched', 'top_users', 'top_platforms', 'most_concurrent']),
+    'HOME_STATS_CARDS': (list, 'General', ['top_movies', 'popular_movies', 'top_tv', 'popular_tv',
+                                           'top_music', 'popular_music', 'last_watched', 'top_users',
+                                           'top_platforms', 'most_concurrent']),
     'HTTPS_CREATE_CERT': (int, 'General', 1),
     'HTTPS_CERT': (str, 'General', ''),
     'HTTPS_KEY': (str, 'General', ''),
@@ -658,8 +661,10 @@ class Config(object):
 
         for key, subkeys in self._config.iteritems():
             for subkey, value in subkeys.iteritems():
-                if isinstance(value, basestring) and len(value.strip()) > 5 and \
-                    subkey.upper() not in _WHITELIST_KEYS and any(bk in subkey.upper() for bk in _BLACKLIST_KEYS):
+                if isinstance(value, basestring) and \
+                                len(value.strip()) > 5 and \
+                                subkey.upper() not in _WHITELIST_KEYS and \
+                                any(bk in subkey.upper() for bk in _BLACKLIST_KEYS):
                     blacklist.append(value.strip())
 
         logger._BLACKLIST_WORDS.extend(blacklist)
@@ -688,7 +693,8 @@ class Config(object):
         self.check_section(section)
         try:
             my_val = definition_type(self._config[section][ini_key])
-        except Exception:
+        except Exception as e:
+            logger.exception(e)
             my_val = definition_type(default)
             self._config[section][ini_key] = my_val
         return my_val
@@ -757,7 +763,7 @@ class Config(object):
 
     def _upgrade(self):
         """
-        Upgrades config file from previous verisions and bumps up config version
+        Upgrades config file from previous versions and bumps up config version
         """
         if self.CONFIG_VERSION == 0:
             # Separate out movie and tv notifications
@@ -786,7 +792,7 @@ class Config(object):
 
         if self.CONFIG_VERSION == 2:
             def rep(s):
-                return s.replace('{progress}','{progress_duration}')
+                return s.replace('{progress}', '{progress_duration}')
 
             self.NOTIFY_ON_START_SUBJECT_TEXT = rep(self.NOTIFY_ON_START_SUBJECT_TEXT)
             self.NOTIFY_ON_START_BODY_TEXT = rep(self.NOTIFY_ON_START_BODY_TEXT)
@@ -804,7 +810,8 @@ class Config(object):
             self.CONFIG_VERSION = 3
 
         if self.CONFIG_VERSION == 3:
-            if self.HTTP_ROOT == '/': self.HTTP_ROOT = ''
+            if self.HTTP_ROOT == '/':
+                self.HTTP_ROOT = ''
             self.CONFIG_VERSION = 4
 
         if self.CONFIG_VERSION == 4:
@@ -829,7 +836,7 @@ class Config(object):
 
         if self.CONFIG_VERSION == 7:
             def rep(s):
-                return s.replace('<tv>','<episode>').replace('</tv>','</episode>').replace('<music>','<track>').replace('</music>','</track>')
+                return s.replace('<tv>', '<episode>').replace('</tv>', '</episode>').replace('<music>', '<track>').replace('</music>', '</track>')
 
             self.NOTIFY_ON_START_SUBJECT_TEXT = rep(self.NOTIFY_ON_START_SUBJECT_TEXT)
             self.NOTIFY_ON_START_BODY_TEXT = rep(self.NOTIFY_ON_START_BODY_TEXT)

--- a/plexpy/database.py
+++ b/plexpy/database.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -13,15 +14,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import arrow
 import os
-import sqlite3
 import shutil
+import sqlite3
 import threading
 import time
 
-import plexpy
+import arrow
+
 import logger
+import plexpy
 
 FILENAME = "plexpy.db"
 db_lock = threading.Lock()
@@ -52,6 +54,7 @@ def delete_sessions():
     except Exception as e:
         logger.warn(u"PlexPy Database :: Unable to clear temporary sessions from database: %s." % e)
         return False
+
 
 def db_filename(filename=FILENAME):
     """ Returns the filepath to the db """

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,12 +14,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import plexpy
 import common
 import database
 import datatables
 import helpers
 import logger
+import plexpy
 import pmsconnect
 import session
 
@@ -249,7 +250,9 @@ class DataFactory(object):
 
         return dict
 
-    def get_home_stats(self, grouping=0, time_range='30', stats_type=0, stats_count='5', stats_cards=[], notify_watched_percent='85'):
+    def get_home_stats(self, grouping=0, time_range='30', stats_type=0, stats_count='5', stats_cards=None, notify_watched_percent='85'):
+        if stats_cards is None:
+            stats_cards = []
         monitor_db = database.MonitorDatabase()
 
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
@@ -589,7 +592,7 @@ class DataFactory(object):
                            'platform_type': '',
                            'platform': '',
                            'row_id': ''
-                    }
+                           }
                     top_users.append(row)
 
                 home_stats.append({'stat_id': stat,
@@ -701,11 +704,11 @@ class DataFactory(object):
             elif stat == 'most_concurrent':
 
                 def calc_most_concurrent(title, result):
-                    '''
+                    """
                     Function to calculate most concurrent streams
                     Input: Stat title, SQLite query result
                     Output: Dict {title, count, started, stopped}
-                    '''
+                    """
                     times = []
                     for item in result:
                         times.append({'time': str(item['started']) + 'B', 'count': 1})
@@ -780,7 +783,9 @@ class DataFactory(object):
 
         return home_stats
 
-    def get_library_stats(self, library_cards=[]):
+    def get_library_stats(self, library_cards=None):
+        if library_cards is None:
+            library_cards = []
         monitor_db = database.MonitorDatabase()
 
         if session.get_session_shared_libraries():
@@ -1277,7 +1282,7 @@ class DataFactory(object):
             genres = ";".join(metadata['genres'])
             labels = ";".join(metadata['labels'])
 
-            #logger.info(u"PlexPy DataFactory :: Updating metadata in the database for rating key: %s." % new_rating_key)
+            # logger.info(u"PlexPy DataFactory :: Updating metadata in the database for rating key: %s." % new_rating_key)
             monitor_db = database.MonitorDatabase()
 
             # Update the session_history_metadata table

--- a/plexpy/datatables.py
+++ b/plexpy/datatables.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -31,16 +32,35 @@ class DataTables(object):
     def ssp_query(self,
                   table_name=None,
                   table_name_union=None,
-                  columns=[],
-                  columns_union=[],
-                  custom_where=[],
-                  custom_where_union=[],
-                  group_by=[],
-                  group_by_union=[],
-                  join_types=[],
-                  join_tables=[],
-                  join_evals=[],
+                  columns=None,
+                  columns_union=None,
+                  custom_where=None,
+                  custom_where_union=None,
+                  group_by=None,
+                  group_by_union=None,
+                  join_types=None,
+                  join_tables=None,
+                  join_evals=None,
                   kwargs=None):
+
+        if columns is None:
+            columns = []
+        if columns_union is None:
+            columns_union = []
+        if custom_where is None:
+            custom_where = []
+        if custom_where_union is None:
+            custom_where_union = []
+        if group_by is None:
+            group_by = []
+        if group_by_union is None:
+            group_by_union = []
+        if join_types is None:
+            join_types = []
+        if join_tables is None:
+            join_tables = []
+        if join_evals is None:
+            join_evals = []
 
         if not table_name:
             logger.error('PlexPy DataTables :: No table name received.')
@@ -112,7 +132,10 @@ class DataTables(object):
 
         return output
 
-    def build_grouping(self, group_by=[]):
+    def build_grouping(self, group_by=None):
+        if group_by is None:
+            group_by = []
+
         # Build grouping
         group = ''
 
@@ -123,7 +146,14 @@ class DataTables(object):
 
         return group
 
-    def build_join(self, join_types=[], join_tables=[], join_evals=[]):
+    def build_join(self, join_types=None, join_tables=None, join_evals=None):
+        if join_types is None:
+            join_types = []
+        if join_tables is None:
+            join_tables = []
+        if join_evals is None:
+            join_evals = []
+
         # Build join parameters
         join = ''
 
@@ -135,7 +165,9 @@ class DataTables(object):
 
         return join
 
-    def build_custom_where(self, custom_where=[]):
+    def build_custom_where(self, custom_where=None):
+        if custom_where is None:
+            custom_where = []
         # Build custom where parameters
         c_where = ''
         args = []
@@ -144,14 +176,14 @@ class DataTables(object):
             if isinstance(w[1], (list, tuple)) and len(w[1]):
                 c_where += '('
                 for w_ in w[1]:
-                    if w_ == None:
+                    if w_ is None:
                         c_where += w[0] + ' IS NULL OR '
                     else:
                         c_where += w[0] + ' = ? OR '
                         args.append(w_)
                 c_where = c_where.rstrip(' OR ') + ') AND '
             else:
-                if w[1] == None:
+                if w[1] is None:
                     c_where += w[0] + ' IS NULL AND '
                 else:
                     c_where += w[0] + ' = ? AND '
@@ -162,7 +194,13 @@ class DataTables(object):
 
         return c_where, args
 
-    def build_order(self, order_param=[], columns=[], dt_columns=[]):
+    def build_order(self, order_param=None, columns=None, dt_columns=None):
+        if order_param is None:
+            order_param = []
+        if columns is None:
+            columns = []
+        if dt_columns is None:
+            dt_columns = []
         # Build ordering
         order = ''
 
@@ -189,7 +227,11 @@ class DataTables(object):
 
         return order
 
-    def build_where(self, search_param='', columns=[], dt_columns=[]):
+    def build_where(self, search_param='', columns=None, dt_columns=None):
+        if columns is None:
+            columns = []
+        if dt_columns is None:
+            dt_columns = []
         # Build where parameters
         where = ''
         args = []

--- a/plexpy/exceptions.py
+++ b/plexpy/exceptions.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -18,4 +19,3 @@ class PlexPyException(Exception):
     """
     Generic PlexPy Exception - should never be thrown, only subclassed
     """
-

--- a/plexpy/graphs.py
+++ b/plexpy/graphs.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,10 +16,10 @@
 
 import datetime
 
-import plexpy
 import common
 import database
 import logger
+import plexpy
 import session
 
 
@@ -250,10 +251,10 @@ class Graphs(object):
             logger.warn(u"PlexPy Graphs :: Unable to execute database query for get_total_plays_per_hourofday: %s." % e)
             return None
 
-        hours_list = ['00','01','02','03','04','05',
-                      '06','07','08','09','10','11',
-                      '12','13','14','15','16','17',
-                      '18','19','20','21','22','23']
+        hours_list = ['00', '01', '02', '03', '04', '05',
+                      '06', '07', '08', '09', '10', '11',
+                      '12', '13', '14', '15', '16', '17',
+                      '18', '19', '20', '21', '22', '23']
 
         categories = []
         series_1 = []
@@ -311,7 +312,7 @@ class Graphs(object):
                         'FROM session_history ' \
                         'WHERE datetime(started, "unixepoch", "localtime") >= datetime("now", "-12 months", "localtime") %s' \
                         'GROUP BY strftime("%%Y-%%m", datetime(started, "unixepoch", "localtime")) ' \
-                        'ORDER BY datestring DESC LIMIT 12' % (user_cond)
+                        'ORDER BY datestring DESC LIMIT 12' % user_cond
 
                 result = monitor_db.select(query)
             else:
@@ -325,7 +326,7 @@ class Graphs(object):
                         'FROM session_history ' \
                         'WHERE datetime(started, "unixepoch", "localtime") >= datetime("now", "-12 months", "localtime") %s' \
                         'GROUP BY strftime("%%Y-%%m", datetime(started, "unixepoch", "localtime")) ' \
-                        'ORDER BY datestring DESC LIMIT 12' % (user_cond)
+                        'ORDER BY datestring DESC LIMIT 12' % user_cond
 
                 result = monitor_db.select(query)
         except Exception as e:

--- a/plexpy/helpers.py
+++ b/plexpy/helpers.py
@@ -1,4 +1,5 @@
-﻿#  This file is part of PlexPy.
+﻿# coding=utf-8
+#  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,29 +16,34 @@
 
 import base64
 import datetime
-from functools import wraps
-import geoip2.database, geoip2.errors
 import gzip
 import hashlib
 import imghdr
-import ipwhois, ipwhois.exceptions, ipwhois.utils
-from IPy import IP
 import json
 import math
-import maxminddb
-from operator import itemgetter
 import os
 import re
 import socket
 import sys
 import time
 import unicodedata
-import urllib, urllib2
+import urllib
+import urllib2
+from functools import wraps
+from operator import itemgetter
 from xml.dom import minidom
-import xmltodict
 
-import plexpy
+import geoip2.database
+import geoip2.errors
+import ipwhois
+import ipwhois.exceptions
+import ipwhois.utils
+import maxminddb
+import xmltodict
+from IPy import IP
+
 import logger
+import plexpy
 from plexpy.api2 import API2
 
 
@@ -53,6 +59,7 @@ def addtoapi(*dargs, **dkwargs):
             @addtoapi()
 
     """
+
     def rd(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
@@ -73,6 +80,7 @@ def addtoapi(*dargs, **dkwargs):
         return wrapper
 
     return rd
+
 
 def multikeysort(items, columns):
     comparers = [((itemgetter(col[1:].strip()), -1) if col.startswith('-') else (itemgetter(col.strip()), 1)) for col in columns]
@@ -96,7 +104,6 @@ def checked(variable):
 
 
 def radio(variable, pos):
-
     if variable == pos:
         return 'Checked'
     else:
@@ -149,7 +156,6 @@ def latinToAscii(unicrap):
 
 
 def convert_milliseconds(ms):
-
     seconds = ms / 1000
     gmtime = time.gmtime(seconds)
     if seconds > 3600:
@@ -159,8 +165,8 @@ def convert_milliseconds(ms):
 
     return minutes
 
-def convert_milliseconds_to_minutes(ms):
 
+def convert_milliseconds_to_minutes(ms):
     if str(ms).isdigit():
         seconds = float(ms) / 1000
         minutes = round(seconds / 60, 0)
@@ -169,8 +175,8 @@ def convert_milliseconds_to_minutes(ms):
 
     return 0
 
-def convert_seconds(s):
 
+def convert_seconds(s):
     gmtime = time.gmtime(s)
     if s > 3600:
         minutes = time.strftime("%H:%M:%S", gmtime)
@@ -179,8 +185,8 @@ def convert_seconds(s):
 
     return minutes
 
-def convert_seconds_to_minutes(s):
 
+def convert_seconds_to_minutes(s):
     if str(s).isdigit():
         minutes = round(float(s) / 60, 0)
 
@@ -199,8 +205,8 @@ def now():
     now = datetime.datetime.now()
     return now.strftime("%Y-%m-%d %H:%M:%S")
 
-def human_duration(s, sig='dhms'):
 
+def human_duration(s, sig='dhms'):
     hd = ''
 
     if str(s).isdigit() and s > 0:
@@ -231,11 +237,12 @@ def human_duration(s, sig='dhms'):
 
     return hd
 
-def get_age(date):
 
+def get_age(date):
     try:
         split_date = date.split('-')
-    except:
+    except Exception as e:
+        logger.exception(e)
         return False
 
     try:
@@ -247,7 +254,6 @@ def get_age(date):
 
 
 def bytes_to_mb(bytes):
-
     mb = int(bytes) / 1048576
     size = '%.1f MB' % mb
     return size
@@ -285,7 +291,6 @@ def piratesize(size):
 
 
 def replace_all(text, dic, normalize=False):
-
     if not text:
         return ''
 
@@ -312,7 +317,6 @@ def replace_illegal_chars(string, type="file"):
 
 
 def cleanName(string):
-
     pass1 = latinToAscii(string).lower()
     out_string = re.sub('[\.\-\/\!\@\#\$\%\^\&\*\(\)\+\-\"\'\,\;\:\[\]\{\}\<\>\=\_]', '', pass1).encode('utf-8')
 
@@ -320,7 +324,6 @@ def cleanName(string):
 
 
 def cleanTitle(title):
-
     title = re.sub('[\.\-\/\_]', ' ', title).lower()
 
     # Strip out extra whitespace
@@ -372,7 +375,7 @@ def extract_logline(s):
         level = match.group("level")
         thread = match.group("thread")
         message = match.group("message")
-        return (timestamp, level, thread, message)
+        return timestamp, level, thread, message
     else:
         return None
 
@@ -382,6 +385,7 @@ def split_string(mystring, splitvar=','):
     for each_word in mystring.split(splitvar):
         mylist.append(each_word.strip())
     return mylist
+
 
 def create_https_certificates(ssl_cert, ssl_key):
     """
@@ -401,7 +405,7 @@ def create_https_certificates(ssl_cert, ssl_key):
     # Create the self-signed PlexPy certificate
     logger.debug(u"Generating self-signed SSL certificate.")
     pkey = createKeyPair(TYPE_RSA, 2048)
-    cert = createSelfSignedCertificate(("PlexPy", pkey), serial, (0, 60 * 60 * 24 * 365 * 10), altNames) # ten years
+    cert = createSelfSignedCertificate(("PlexPy", pkey), serial, (0, 60 * 60 * 24 * 365 * 10), altNames)  # ten years
 
     # Save the key and certificate to disk
     try:
@@ -422,11 +426,13 @@ def cast_to_int(s):
     except (ValueError, TypeError):
         return 0
 
+
 def cast_to_float(s):
     try:
         return float(s)
     except (ValueError, TypeError):
         return 0
+
 
 def convert_xml_to_json(xml):
     o = xmltodict.parse(xml)
@@ -439,7 +445,6 @@ def convert_xml_to_dict(xml):
 
 
 def get_percent(value1, value2):
-
     if str(value1).isdigit() and str(value2).isdigit():
         value1 = cast_to_float(value1)
         value2 = cast_to_float(value2)
@@ -453,6 +458,7 @@ def get_percent(value1, value2):
 
     return math.trunc(percent)
 
+
 def parse_xml(unparsed=None):
     if unparsed:
         try:
@@ -461,16 +467,17 @@ def parse_xml(unparsed=None):
         except Exception as e:
             logger.warn("Error parsing XML. %s" % e)
             return []
-        except:
-            logger.warn("Error parsing XML.")
-            return []
+
     else:
         logger.warn("XML parse request made but no data received.")
         return []
 
+
 """
 Validate xml keys to make sure they exist and return their attribute value, return blank value is none found
 """
+
+
 def get_xml_attr(xml_key, attribute, return_bool=False, default_return=''):
     if xml_key.getAttribute(attribute):
         if return_bool:
@@ -483,6 +490,7 @@ def get_xml_attr(xml_key, attribute, return_bool=False, default_return=''):
         else:
             return default_return
 
+
 def process_json_kwargs(json_kwargs):
     params = {}
     if json_kwargs:
@@ -490,11 +498,13 @@ def process_json_kwargs(json_kwargs):
 
     return params
 
+
 def sanitize(string):
     if string:
-        return unicode(string).replace('<','&lt;').replace('>','&gt;')
+        return unicode(string).replace('<', '&lt;').replace('>', '&gt;')
     else:
         return ''
+
 
 def is_ip_public(host):
     ip_address = get_ip(host)
@@ -503,6 +513,7 @@ def is_ip_public(host):
         return True
 
     return False
+
 
 def get_ip(host):
     ip_address = ''
@@ -513,10 +524,12 @@ def get_ip(host):
         try:
             ip_address = socket.gethostbyname(host)
             logger.debug(u"IP Checker :: Resolved %s to %s." % (host, ip_address))
-        except:
+        except Exception as e:
+            logger.exception(e)
             logger.error(u"IP Checker :: Bad IP or hostname provided.")
 
     return ip_address
+
 
 def install_geoip_db():
     maxmind_url = 'http://geolite.maxmind.com/download/geoip/database/'
@@ -578,6 +591,7 @@ def install_geoip_db():
 
     return True
 
+
 def uninstall_geoip_db():
     logger.debug(u"PlexPy Helpers :: Uninstalling the GeoLite2 database...")
     try:
@@ -591,10 +605,11 @@ def uninstall_geoip_db():
     logger.debug(u"PlexPy Helpers :: GeoLite2 database uninstalled successfully.")
     return True
 
+
 def geoip_lookup(ip_address):
     if not plexpy.CONFIG.GEOIP_DB:
         return 'GeoLite2 database not installed. Please install from the ' \
-            '<a href="settings?install_geoip=true">Settings</a> page.'
+               '<a href="settings?install_geoip=true">Settings</a> page.'
 
     if not ip_address:
         return 'No IP address provided.'
@@ -607,10 +622,10 @@ def geoip_lookup(ip_address):
         return 'Invalid IP address provided: %s.' % ip_address
     except IOError as e:
         return 'Missing GeoLite2 database. Please reinstall from the ' \
-            '<a href="settings?install_geoip=true">Settings</a> page.'
+               '<a href="settings?install_geoip=true">Settings</a> page.'
     except maxminddb.InvalidDatabaseError as e:
         return 'Invalid GeoLite2 database. Please reinstall from the ' \
-            '<a href="settings?reinstall_geoip=true">Settings</a> page.'
+               '<a href="settings?reinstall_geoip=true">Settings</a> page.'
     except geoip2.errors.AddressNotFoundError as e:
         return '%s' % e
     except Exception as e:
@@ -629,8 +644,8 @@ def geoip_lookup(ip_address):
 
     return geo_info
 
-def whois_lookup(ip_address):
 
+def whois_lookup(ip_address):
     nets = []
     err = None
     try:
@@ -640,7 +655,7 @@ def whois_lookup(ip_address):
         for net in nets:
             net['country'] = countries[net['country']]
             if net['postal_code']:
-                 net['postal_code'] = net['postal_code'].replace('-', ' ')
+                net['postal_code'] = net['postal_code'].replace('-', ' ')
     except ValueError as e:
         err = 'Invalid IP address provided: %s.' % ip_address
     except ipwhois.exceptions.IPDefinedError as e:
@@ -654,6 +669,7 @@ def whois_lookup(ip_address):
     try:
         host = ipwhois.Net(ip_address).get_host(retry_count=0)[0]
     except Exception as e:
+        logger.exception(e)
         host = 'Not available'
 
     whois_info = {"host": host,
@@ -665,12 +681,14 @@ def whois_lookup(ip_address):
 
     return whois_info
 
+
 # Taken from SickRage
 def anon_url(*url):
     """
     Return a URL string consisting of the Anonymous redirect URL and an arbitrary number of values appended.
     """
     return '' if None in url else '%s%s' % (plexpy.CONFIG.ANON_REDIRECT, ''.join(str(s) for s in url))
+
 
 def uploadToImgur(imgPath, imgTitle=''):
     """ Uploads an image to Imgur """
@@ -699,19 +717,20 @@ def uploadToImgur(imgPath, imgTitle=''):
         request = urllib2.Request('https://api.imgur.com/3/image', headers=headers, data=urllib.urlencode(data))
         response = urllib2.urlopen(request)
         response = json.loads(response.read())
-    
+
         if response.get('status') == 200:
             t = '\'' + imgTitle + '\' ' if imgTitle else ''
             logger.debug(u"PlexPy Helpers :: Image %suploaded to Imgur." % t)
             img_url = response.get('data').get('link', '')
-        elif response.get('status') >= 400 and response.get('status') < 500:
+        elif 400 <= response.get('status') < 500:
             logger.warn(u"PlexPy Helpers :: Unable to upload image to Imgur: %s" % response.reason)
         else:
             logger.warn(u"PlexPy Helpers :: Unable to upload image to Imgur.")
     except (urllib2.HTTPError, urllib2.URLError) as e:
-            logger.warn(u"PlexPy Helpers :: Unable to upload image to Imgur: %s" % e)
+        logger.warn(u"PlexPy Helpers :: Unable to upload image to Imgur: %s" % e)
 
     return img_url
+
 
 def cache_image(url, image=None):
     """
@@ -745,6 +764,7 @@ def cache_image(url, image=None):
 
     return imagefile, imagetype
 
+
 def build_datatables_json(kwargs, dt_columns, default_sort_col=None):
     """ Builds datatables json data
 
@@ -760,14 +780,15 @@ def build_datatables_json(kwargs, dt_columns, default_sort_col=None):
 
     # Build json data
     json_data = {"draw": 1,
-                    "columns": columns,
-                    "order": [{"column": order_column,
+                 "columns": columns,
+                 "order": [{"column": order_column,
                             "dir": kwargs.pop("order_dir", "desc")}],
-                    "start": int(kwargs.pop("start", 0)),
-                    "length": int(kwargs.pop("length", 25)),
-                    "search": {"value": kwargs.pop("search", "")}
-                    }
+                 "start": int(kwargs.pop("start", 0)),
+                 "length": int(kwargs.pop("length", 25)),
+                 "search": {"value": kwargs.pop("search", "")}
+                 }
     return json.dumps(json_data)
+
 
 def humanFileSize(bytes, si=False):
     if str(bytes).isdigit():

--- a/plexpy/http_handler.py
+++ b/plexpy/http_handler.py
@@ -16,13 +16,13 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-from httplib import HTTPSConnection
-from httplib import HTTPConnection
 import ssl
+from httplib import HTTPConnection
+from httplib import HTTPSConnection
 
-import plexpy
 import helpers
 import logger
+import plexpy
 
 
 class HTTPHandler(object):
@@ -90,9 +90,6 @@ class HTTPHandler(object):
                 return None
             except Exception as e:
                 logger.warn(u"Failed to access uri endpoint %s. Is your server maybe accepting SSL connections only? %s" % (uri, e))
-                return None
-            except:
-                logger.warn(u"Failed to access uri endpoint %s with Uncaught exception." % uri)
                 return None
 
             if request_status in (200, 201):

--- a/plexpy/lock.py
+++ b/plexpy/lock.py
@@ -1,11 +1,13 @@
+# coding=utf-8
 """
 Locking-related classes
 """
 
-import plexpy.logger
-import time
-import threading
 import Queue
+import threading
+import time
+
+import plexpy.logger
 
 
 class TimedLock(object):

--- a/plexpy/log_reader.py
+++ b/plexpy/log_reader.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -15,9 +16,10 @@
 
 import os
 
-import plexpy
 import helpers
 import logger
+import plexpy
+
 
 def get_log_tail(window=20, parsed=True, log_type="server"):
 
@@ -45,11 +47,12 @@ def get_log_tail(window=20, parsed=True, log_type="server"):
             try:
                 i = helpers.latinToAscii(i)
                 log_time = i.split(' [')[0]
-                log_level = i.split('] ', 1)[1].split(' - ',1)[0]
-                log_msg = i.split('] ', 1)[1].split(' - ',1)[1]
+                log_level = i.split('] ', 1)[1].split(' - ', 1)[0]
+                log_msg = i.split('] ', 1)[1].split(' - ', 1)[1]
                 full_line = [log_time, log_level, log_msg]
                 clean_lines.append(full_line)
-            except:
+            except Exception as e:
+                logger.exception(e)
                 line_error = True
                 full_line = ['', '', 'Unable to parse log line.']
                 clean_lines.append(full_line)
@@ -65,7 +68,6 @@ def get_log_tail(window=20, parsed=True, log_type="server"):
 
         return raw_lines
 
-    return log_lines
 
 # http://stackoverflow.com/a/13790289/2405162
 def tail(f, lines=1, _buffer=4098):

--- a/plexpy/logger.py
+++ b/plexpy/logger.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -13,9 +14,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-from logutils.queue import QueueHandler, QueueListener
-from logging import handlers
-
 import contextlib
 import errno
 import logging
@@ -25,9 +23,12 @@ import re
 import sys
 import threading
 import traceback
+from logging import handlers
 
-import plexpy
+from logutils.queue import QueueHandler, QueueListener
+
 import helpers
+import plexpy
 
 # These settings are for file logging only
 FILENAME = "plexpy.log"

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1,4 +1,5 @@
-﻿#  This file is part of PlexPy.
+﻿# coding=utf-8
+#  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,38 +15,36 @@
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
 import base64
-import bleach
-import json
-import cherrypy
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 import email.utils
-from httplib import HTTPSConnection
+import json
 import os
-import requests
 import shlex
 import smtplib
 import subprocess
 import threading
 import time
 import urllib
-from urllib import urlencode
 import urllib2
-from urlparse import urlparse
 import uuid
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from httplib import HTTPSConnection
+from urllib import urlencode
+from urlparse import urlparse
 
-import gntp.notifier
+import bleach
 import facebook
-import twitter
+import gntp.notifier
 import pynma
+import requests
+import twitter
 
-import plexpy
 import database
 import helpers
 import logger
+import plexpy
 import request
 from plexpy.config import _BLACKLIST_KEYS, _WHITELIST_KEYS
-from plexpy.helpers import checked
 
 AGENT_IDS = {'growl': 0,
              'prowl': 1,
@@ -530,7 +529,7 @@ def blacklist_logger():
         config = json.loads(n['notifier_config'] or '{}')
         for key, value in config.iteritems():
             if isinstance(value, basestring) and len(value.strip()) > 5 and \
-                key.upper() not in _WHITELIST_KEYS and any(bk in key.upper() for bk in blacklist_keys):
+                            key.upper() not in _WHITELIST_KEYS and any(bk in key.upper() for bk in blacklist_keys):
                 blacklist.append(value.strip())
 
     logger._BLACKLIST_WORDS.extend(blacklist)
@@ -538,8 +537,8 @@ def blacklist_logger():
 
 class PrettyMetadata(object):
     def __init__(self, parameters):
-    	self.parameters = parameters
-    	self.media_type = parameters['media_type']
+        self.parameters = parameters
+        self.media_type = parameters['media_type']
 
     def get_poster_url(self):
         self.poster_url = self.parameters['poster_url']
@@ -574,7 +573,7 @@ class PrettyMetadata(object):
             self.caption = 'View on Last.fm'
         return self.caption
 
-    def get_title(self, divider = '-'):
+    def get_title(self, divider='-'):
         self.title = ''
         if self.media_type == 'movie':
             self.title = '%s (%s)' % (self.parameters['title'], self.parameters['year'])
@@ -689,7 +688,7 @@ class BOXCAR(Notifier):
                   'flourish': 'Flourish',
                   'harp': 'Harp',
                   'light': 'Light',
-                  'magic-chime':'Magic Chime',
+                  'magic-chime': 'Magic Chime',
                   'magic-coin': 'Magic Coin',
                   'no-sound': 'No Sound',
                   'notifier-1': 'Notifier (1)',
@@ -853,7 +852,7 @@ class DISCORD(Notifier):
         if request_status == 200:
             logger.info(u"PlexPy Notifiers :: Discord notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Discord notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -867,17 +866,17 @@ class DISCORD(Notifier):
                           'description': 'Your Discord incoming webhook URL.',
                           'input_type': 'text'
                           },
-                          {'label': 'Discord Username',
-                           'value': self.config['username'],
-                           'name': 'discord_username',
-                           'description': 'The Discord username which will be used. Leave blank for webhook integration default.',
-                           'input_type': 'text'
+                         {'label': 'Discord Username',
+                          'value': self.config['username'],
+                          'name': 'discord_username',
+                          'description': 'The Discord username which will be used. Leave blank for webhook integration default.',
+                          'input_type': 'text'
                           },
-                          {'label': 'Discord Avatar',
-                           'value': self.config['avatar_url'],
-                           'description': 'The image url for the avatar which will be used. Leave blank for webhook integration default.',
-                           'name': 'discord_avatar_url',
-                           'input_type': 'text'
+                         {'label': 'Discord Avatar',
+                          'value': self.config['avatar_url'],
+                          'description': 'The image url for the avatar which will be used. Leave blank for webhook integration default.',
+                          'name': 'discord_avatar_url',
+                          'input_type': 'text'
                           },
                          {'label': 'TTS',
                           'value': self.config['tts'],
@@ -1066,7 +1065,7 @@ class FACEBOOK(Notifier):
 
         return facebook.auth_url(app_id=app_id,
                                  canvas_url=redirect_uri + '/facebookStep2',
-                                 perms=['user_managed_groups','publish_actions'])
+                                 perms=['user_managed_groups', 'publish_actions'])
 
     def _get_credentials(self, code=''):
         logger.info(u"PlexPy Notifiers :: Requesting access token from Facebook")
@@ -1278,8 +1277,7 @@ class GROWL(Notifier):
         body = body.encode(plexpy.SYS_ENCODING, "replace")
 
         # Send it, including an image
-        image_file = os.path.join(str(plexpy.PROG_DIR),
-            "data/interfaces/default/images/favicon.png")
+        image_file = os.path.join(str(plexpy.PROG_DIR), "data/interfaces/default/images/favicon.png")
 
         with open(image_file, 'rb') as f:
             image = f.read()
@@ -1328,7 +1326,7 @@ class HIPCHAT(Notifier):
                        }
 
     def notify(self, subject='', body='', action='', **kwargs):
-        if not subjecy or not body:
+        if not subject or not body:
             return
 
         data = {'notify': 'false'}
@@ -1396,7 +1394,7 @@ class HIPCHAT(Notifier):
         if request_status == 200 or request_status == 204:
             logger.info(u"PlexPy Notifiers :: Hipchat notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Hipchat notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -1484,7 +1482,7 @@ class IFTTT(Notifier):
         if request_status == 200:
             logger.info(u"PlexPy Notifiers :: Ifttt notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Ifttt notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -1549,7 +1547,7 @@ class JOIN(Notifier):
                 error_msg = data.get('errorMessage')
                 logger.info(u"PlexPy Notifiers :: Join notification failed: %s" % error_msg)
                 return False
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Join notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -1576,7 +1574,7 @@ class JOIN(Notifier):
                     error_msg = data.get('errorMessage')
                     logger.info(u"PlexPy Notifiers :: Unable to retrieve Join devices list: %s" % error_msg)
                     return {'': ''}
-            elif request_status >= 400 and request_status < 500:
+            elif 400 <= request_status < 500:
                 logger.warn(u"PlexPy Notifiers :: Unable to retrieve Join devices list: %s" % response.reason)
                 return {'': ''}
             else:
@@ -1602,8 +1600,9 @@ class JOIN(Notifier):
                          {'label': 'Device ID(s) or Group ID',
                           'value': self.config['device_id'],
                           'name': 'join_device_id',
-                          'description': 'Set your Join device ID or group ID. ' \
-                              'Separate multiple devices with commas (,).',
+                          'description': 'Set your Join device ID or group ID. '
+                                         'Separate multiple devices with commas '
+                                         '(,).',
                           'input_type': 'text',
                           },
                          {'label': 'Your Devices IDs',
@@ -1684,7 +1683,8 @@ class OSX(Notifier):
         try:
             self.objc = __import__("objc")
             self.AppKit = __import__("AppKit")
-        except:
+        except Exception as e:
+            logger.exception(e)
             # logger.error(u"PlexPy Notifiers :: Cannot load OSX Notifications agent.")
             pass
 
@@ -1693,7 +1693,8 @@ class OSX(Notifier):
             self.objc = __import__("objc")
             self.AppKit = __import__("AppKit")
             return True
-        except:
+        except Exception as e:
+            logger.exception(e)
             return False
 
     def _swizzle(self, cls, SEL, func):
@@ -1716,8 +1717,8 @@ class OSX(Notifier):
 
         try:
             self._swizzle(self.objc.lookUpClass('NSBundle'),
-                b'bundleIdentifier',
-                self._swizzled_bundleIdentifier)
+                          b'bundleIdentifier',
+                          self._swizzled_bundleIdentifier)
 
             NSUserNotification = self.objc.lookUpClass('NSUserNotification')
             NSUserNotificationCenter = self.objc.lookUpClass('NSUserNotificationCenter')
@@ -1786,7 +1787,9 @@ class PLEX(Notifier):
         else:
             return request.request_content(url)
 
-    def _sendjson(self, host, method, params={}):
+    def _sendjson(self, host, method, params=None):
+        if params is None:
+            params = {}
         data = [{'id': 0, 'jsonrpc': '2.0', 'method': method, 'params': params}]
         headers = {'Content-Type': 'application/json'}
         url = host + '/jsonrpc'
@@ -2004,7 +2007,7 @@ class PUSHBULLET(Notifier):
         http_handler.request("POST",
                              "/v2/pushes",
                              headers={'Content-type': "application/json",
-                             'Authorization': 'Basic %s' % base64.b64encode(self.config['apikey'] + ":")},
+                                      'Authorization': 'Basic %s' % base64.b64encode(self.config['apikey'] + ":")},
                              body=json.dumps(data))
         response = http_handler.getresponse()
         request_status = response.status
@@ -2012,7 +2015,7 @@ class PUSHBULLET(Notifier):
         if request_status == 200:
             logger.info(u"PlexPy Notifiers :: PushBullet notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: PushBullet notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -2024,7 +2027,7 @@ class PUSHBULLET(Notifier):
             http_handler = HTTPSConnection("api.pushbullet.com")
             http_handler.request("GET", "/v2/devices",
                                  headers={'Content-type': "application/json",
-                                 'Authorization': 'Basic %s' % base64.b64encode(self.config['apikey'] + ":")})
+                                          'Authorization': 'Basic %s' % base64.b64encode(self.config['apikey'] + ":")})
 
             response = http_handler.getresponse()
             request_status = response.status
@@ -2035,7 +2038,7 @@ class PUSHBULLET(Notifier):
                 devices = {d['iden']: d['nickname'] for d in devices if d['active']}
                 devices.update({'': ''})
                 return devices
-            elif request_status >= 400 and request_status < 500:
+            elif 400 <= request_status < 500:
                 logger.warn(u"PlexPy Notifiers :: Unable to retrieve Pushbullet devices list: %s" % response.reason)
                 return {'': ''}
             else:
@@ -2056,8 +2059,8 @@ class PUSHBULLET(Notifier):
                          {'label': 'Device',
                           'value': self.config['deviceid'],
                           'name': 'pushbullet_deviceid',
-                          'description': 'Set your Pushbullet device. If set, will override channel tag. ' \
-                              'Leave blank to notify on all devices.',
+                          'description': 'Set your Pushbullet device. If set, will override channel tag. '
+                                         'Leave blank to notify on all devices.',
                           'input_type': 'select',
                           'select_options': self.get_devices()
                           },
@@ -2122,7 +2125,7 @@ class PUSHOVER(Notifier):
         if request_status == 200:
             logger.info(u"PlexPy Notifiers :: Pushover notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Pushover notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -2141,7 +2144,7 @@ class PUSHOVER(Notifier):
                 sounds = data.get('sounds', {})
                 sounds.update({'': ''})
                 return sounds
-            elif request_status >= 400 and request_status < 500:
+            elif 400 <= request_status < 500:
                 logger.warn(u"PlexPy Notifiers :: Unable to retrieve Pushover notification sounds list: %s" % response.reason)
                 return {'': ''}
             else:
@@ -2264,11 +2267,13 @@ class SCRIPTS(Notifier):
                 timer = None
 
             try:
-                if timer: timer.start()
+                if timer:
+                    timer.start()
                 output, error = process.communicate()
                 status = process.returncode
             finally:
-                if timer: timer.cancel()
+                if timer:
+                    timer.cancel()
 
         except OSError as e:
             logger.error(u"PlexPy Notifiers :: Failed to run script: %s" % e)
@@ -2353,8 +2358,8 @@ class SCRIPTS(Notifier):
 
     def return_config_options(self):
         config_option = [{'label': 'Supported File Types',
-                          'description': '<span class="inline-pre">' + \
-                              ', '.join(self.script_exts.keys()) + '</span>',
+                          'description': '<span class="inline-pre">' +
+                                         ', '.join(self.script_exts.keys()) + '</span>',
                           'input_type': 'help'
                           },
                          {'label': 'Script Folder',
@@ -2465,7 +2470,7 @@ class SLACK(Notifier):
         if request_status == 200:
             logger.info(u"PlexPy Notifiers :: Slack notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Slack notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -2485,23 +2490,23 @@ class SLACK(Notifier):
                           'description': 'The Slack channel name (begins with \'#\') which will be used. Leave blank for webhook integration default.',
                           'input_type': 'text'
                           },
-                          {'label': 'Slack Username',
-                           'value': self.config['username'],
-                           'name': 'slack_username',
-                           'description': 'The Slack username which will be used. Leave blank for webhook integration default.',
-                           'input_type': 'text'
+                         {'label': 'Slack Username',
+                          'value': self.config['username'],
+                          'name': 'slack_username',
+                          'description': 'The Slack username which will be used. Leave blank for webhook integration default.',
+                          'input_type': 'text'
                           },
-                          {'label': 'Slack Icon',
-                           'value': self.config['icon_emoji'],
-                           'description': 'The Slack emoji or image url for the icon which will be used. Leave blank for webhook integration default.',
-                           'name': 'slack_icon_emoji',
-                           'input_type': 'text'
+                         {'label': 'Slack Icon',
+                          'value': self.config['icon_emoji'],
+                          'description': 'The Slack emoji or image url for the icon which will be used. Leave blank for webhook integration default.',
+                          'name': 'slack_icon_emoji',
+                          'input_type': 'text'
                           },
-                          {'label': 'Slack Color',
-                           'value': self.config['color'],
-                           'description': 'The hex color value (begins with \'#\') for the border along the left side of the message attachment.',
-                           'name': 'slack_color',
-                           'input_type': 'text'
+                         {'label': 'Slack Color',
+                          'value': self.config['color'],
+                          'description': 'The hex color value (begins with \'#\') for the border along the left side of the message attachment.',
+                          'name': 'slack_color',
+                          'input_type': 'text'
                           },
                          {'label': 'Include Poster Image',
                           'value': self.config['incl_poster'],
@@ -2554,7 +2559,7 @@ class TELEGRAM(Notifier):
                            'disable_notification': True}
 
             parameters = kwargs['parameters']
-            poster_url = parameters.get('poster_url','')
+            poster_url = parameters.get('poster_url', '')
 
             if poster_url:
                 files = {'photo': (poster_url, urllib.urlopen(poster_url).read())}
@@ -2566,7 +2571,7 @@ class TELEGRAM(Notifier):
 
                 if request_status == 200:
                     logger.info(u"PlexPy Notifiers :: Telegram poster sent.")
-                elif request_status >= 400 and request_status < 500:
+                elif 400 <= request_status < 500:
                     logger.warn(u"PlexPy Notifiers :: Telegram poster failed: %s" % request_content.get('description'))
                 else:
                     logger.warn(u"PlexPy Notifiers :: Telegram poster failed.")
@@ -2591,7 +2596,7 @@ class TELEGRAM(Notifier):
         if request_status == 200:
             logger.info(u"PlexPy Notifiers :: Telegram notification sent.")
             return True
-        elif request_status >= 400 and request_status < 500:
+        elif 400 <= request_status < 500:
             logger.warn(u"PlexPy Notifiers :: Telegram notification failed: [%s] %s" % (request_status, response.reason))
             return False
         else:
@@ -2685,7 +2690,7 @@ class TWITTER(Notifier):
         poster_url = ''
         if self.config['incl_poster'] and kwargs.get('parameters'):
             parameters = kwargs['parameters']
-            poster_url = parameters.get('poster_url','')
+            poster_url = parameters.get('poster_url', '')
 
         if self.config['incl_subject']:
             return self._send_tweet(subject + '\r\n' + body, attachment=poster_url)
@@ -2763,7 +2768,9 @@ class XBMC(Notifier):
         else:
             return request.request_content(url)
 
-    def _sendjson(self, host, method, params={}):
+    def _sendjson(self, host, method, params=None):
+        if params is None:
+            params = {}
         data = [{'id': 0, 'jsonrpc': '2.0', 'method': method, 'params': params}]
         headers = {'Content-Type': 'application/json'}
         url = host + '/jsonrpc'
@@ -2939,7 +2946,8 @@ def upgrade_config_to_db():
                 # Reverse the dict to {script: [actions]}
                 script_actions = {}
                 for k, v in action_scripts.items():
-                    if v: script_actions.setdefault(v, set()).add(k)
+                    if v:
+                        script_actions.setdefault(v, set()).add(k)
 
                 # Add a new script notifier for each script if the action was enabled
                 for script, actions in script_actions.items():

--- a/plexpy/plexivity_import.py
+++ b/plexpy/plexivity_import.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,12 +14,11 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import arrow
 import sqlite3
 from xml.dom import minidom
 
-import plexpy
-import activity_pinger
+import arrow
+
 import activity_processor
 import database
 import helpers
@@ -32,8 +32,9 @@ def extract_plexivity_xml(xml=None):
     clean_xml = helpers.latinToAscii(xml)
     try:
         xml_parse = minidom.parseString(clean_xml)
-    except:
+    except Exception as e:
         logger.warn(u"PlexPy Importer :: Error parsing XML for Plexivity database.")
+        logger.exception(e)
         return None
 
     # I think Plexivity only tracked videos and not music?
@@ -234,6 +235,7 @@ def extract_plexivity_xml(xml=None):
 
     return output
 
+
 def validate_database(database=None, table_name=None):
     try:
         connection = sqlite3.connect(database, timeout=20)
@@ -243,8 +245,9 @@ def validate_database(database=None, table_name=None):
     except ValueError:
         logger.error(u"PlexPy Importer :: Invalid database specified.")
         return 'Invalid database specified.'
-    except:
+    except Exception as e:
         logger.error(u"PlexPy Importer :: Uncaught exception.")
+        logger.exception(e)
         return 'Uncaught exception.'
 
     try:
@@ -253,11 +256,13 @@ def validate_database(database=None, table_name=None):
     except sqlite3.OperationalError:
         logger.error(u"PlexPy Importer :: Invalid database specified.")
         return 'Invalid database specified.'
-    except:
+    except Exception as e:
         logger.error(u"PlexPy Importer :: Uncaught exception.")
+        logger.exception(e)
         return 'Uncaught exception.'
 
     return 'success'
+
 
 def import_from_plexivity(database=None, table_name=None, import_ignore_interval=0):
 
@@ -285,8 +290,9 @@ def import_from_plexivity(database=None, table_name=None, import_ignore_interval
     # Get the latest friends list so we can pull user id's
     try:
         plextv.refresh_users()
-    except:
+    except Exception as e:
         logger.debug(u"PlexPy Importer :: Unable to refresh the users list. Aborting import.")
+        logger.exception(e)
         return None
 
     query = 'SELECT id AS id, ' \
@@ -324,7 +330,7 @@ def import_from_plexivity(database=None, table_name=None, import_ignore_interval
             continue
 
         # Skip line if we don't have a ratingKey to work with
-        #if not row['rating_key']:
+        # if not row['rating_key']:
         #    logger.error(u"PlexPy Importer :: Skipping record due to null ratingKey.")
         #    continue
 
@@ -422,6 +428,7 @@ def import_from_plexivity(database=None, table_name=None, import_ignore_interval
     logger.debug(u"PlexPy Importer :: Plexivity data import complete.")
     import_users()
 
+
 def import_users():
     logger.debug(u"PlexPy Importer :: Importing Plexivity Users...")
     monitor_db = database.MonitorDatabase()
@@ -433,5 +440,6 @@ def import_users():
     try:
         monitor_db.action(query)
         logger.debug(u"PlexPy Importer :: Users imported.")
-    except:
+    except Exception as e:
         logger.debug(u"PlexPy Importer :: Failed to import users.")
+        logger.exception(e)

--- a/plexpy/plextv.py
+++ b/plexpy/plextv.py
@@ -20,15 +20,15 @@ import base64
 import json
 from xml.dom import minidom
 
-import plexpy
 import common
 import database
 import helpers
 import http_handler
 import logger
-import users
+import plexpy
 import pmsconnect
 import session
+import users
 
 
 def refresh_users():
@@ -218,8 +218,9 @@ class PlexTV(object):
                 logger.debug(u"PlexPy PlexTV :: Removing PlexPy from Plex.tv devices.")
                 try:
                     self.delete_plextv_device(device_id=device_id)
-                except:
+                except Exception as e:
                     logger.error(u"PlexPy PlexTV :: Failed to remove PlexPy from Plex.tv devices.")
+                    logger.exception(e)
                     return None
             else:
                 logger.warn(u"PlexPy PlexTV :: No existing PlexPy device found.")
@@ -232,7 +233,6 @@ class PlexTV(object):
             plexpy.CONFIG.write()
             logger.info(u"PlexPy PlexTV :: Updated Plex.tv token for PlexPy.")
             return token
-
 
     def get_server_token(self):
         servers = self.get_plextv_server_list(output_format='xml')
@@ -347,9 +347,6 @@ class PlexTV(object):
         except Exception as e:
             logger.warn(u"PlexPy PlexTV :: Unable to parse XML for get_full_users_list own account: %s" % e)
             return []
-        except:
-            logger.warn(u"PlexPy PlexTV :: Unable to parse XML for get_full_users_list own account.")
-            return []
 
         xml_head = xml_parse.getElementsByTagName('user')
         if not xml_head:
@@ -376,9 +373,6 @@ class PlexTV(object):
             xml_parse = minidom.parseString(friends_list)
         except Exception as e:
             logger.warn(u"PlexPy PlexTV :: Unable to parse XML for get_full_users_list friends list: %s" % e)
-            return []
-        except:
-            logger.warn(u"PlexPy PlexTV :: Unable to parse XML for get_full_users_list friends list.")
             return []
 
         xml_head = xml_parse.getElementsByTagName('User')
@@ -414,9 +408,6 @@ class PlexTV(object):
             xml_parse = minidom.parseString(sync_list)
         except Exception as e:
             logger.warn(u"PlexPy PlexTV :: Unable to parse XML for get_synced_items: %s" % e)
-            return []
-        except:
-            logger.warn(u"PlexPy PlexTV :: Unable to parse XML for get_synced_items.")
             return []
 
         xml_head = xml_parse.getElementsByTagName('SyncList')
@@ -575,7 +566,7 @@ class PlexTV(object):
 
                     for connection in connections:
                         if helpers.get_xml_attr(connection, 'address') == plexpy.CONFIG.PMS_IP and \
-                            int(helpers.get_xml_attr(connection, 'port')) == plexpy.CONFIG.PMS_PORT:
+                                        int(helpers.get_xml_attr(connection, 'port')) == plexpy.CONFIG.PMS_PORT:
     
                             plexpy.CONFIG.PMS_IDENTIFIER = helpers.get_xml_attr(a, 'clientIdentifier')
                             plexpy.CONFIG.write()
@@ -632,19 +623,19 @@ class PlexTV(object):
 
                 for d in devices:
                     if helpers.get_xml_attr(d, 'presence') == '1' and \
-                        helpers.get_xml_attr(d, 'owned') == '1' and \
-                        helpers.get_xml_attr(d, 'provides') == 'server':
+                                   helpers.get_xml_attr(d, 'owned') == '1' and \
+                                   helpers.get_xml_attr(d, 'provides') == 'server':
                         connections = d.getElementsByTagName('Connection')
 
                         for c in connections:
                             # If this is a remote server don't show any local IPs.
                             if helpers.get_xml_attr(d, 'publicAddressMatches') == '0' and \
-                                helpers.get_xml_attr(c, 'local') == '1':
+                                    helpers.get_xml_attr(c, 'local') == '1':
                                 continue
 
                             # If this is a local server don't show any remote IPs.
                             if helpers.get_xml_attr(d, 'publicAddressMatches') == '1' and \
-                                helpers.get_xml_attr(c, 'local') == '0':
+                                    helpers.get_xml_attr(c, 'local') == '0':
                                 continue
 
                             server = {'httpsRequired': helpers.get_xml_attr(d, 'httpsRequired'),
@@ -670,6 +661,7 @@ class PlexTV(object):
             available_downloads = json.loads(plex_downloads)
         except Exception as e:
             logger.warn(u"PlexPy PlexTV :: Unable to load JSON for get_plex_updates.")
+            logger.exception(e)
             return {}
 
         # Get the updates for the platform

--- a/plexpy/plexwatch_import.py
+++ b/plexpy/plexwatch_import.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -16,8 +17,6 @@
 import sqlite3
 from xml.dom import minidom
 
-import plexpy
-import activity_pinger
 import activity_processor
 import database
 import helpers
@@ -31,8 +30,9 @@ def extract_plexwatch_xml(xml=None):
     clean_xml = helpers.latinToAscii(xml)
     try:
         xml_parse = minidom.parseString(clean_xml)
-    except:
+    except Exception as e:
         logger.warn(u"PlexPy Importer :: Error parsing XML for PlexWatch database.")
+        logger.exception(e)
         return None
 
     xml_head = xml_parse.getElementsByTagName('opt')
@@ -225,6 +225,7 @@ def extract_plexwatch_xml(xml=None):
 
     return output
 
+
 def validate_database(database=None, table_name=None):
     try:
         connection = sqlite3.connect(database, timeout=20)
@@ -234,8 +235,9 @@ def validate_database(database=None, table_name=None):
     except ValueError:
         logger.error(u"PlexPy Importer :: Invalid database specified.")
         return 'Invalid database specified.'
-    except:
+    except Exception as e:
         logger.error(u"PlexPy Importer :: Uncaught exception.")
+        logger.exception(e)
         return 'Uncaught exception.'
 
     try:
@@ -244,11 +246,13 @@ def validate_database(database=None, table_name=None):
     except sqlite3.OperationalError:
         logger.error(u"PlexPy Importer :: Invalid database specified.")
         return 'Invalid database specified.'
-    except:
+    except Exception as e:
         logger.error(u"PlexPy Importer :: Uncaught exception.")
+        logger.exception(e)
         return 'Uncaught exception.'
 
     return 'success'
+
 
 def import_from_plexwatch(database=None, table_name=None, import_ignore_interval=0):
 
@@ -276,8 +280,9 @@ def import_from_plexwatch(database=None, table_name=None, import_ignore_interval
     # Get the latest friends list so we can pull user id's
     try:
         plextv.refresh_users()
-    except:
+    except Exception as e:
         logger.debug(u"PlexPy Importer :: Unable to refresh the users list. Aborting import.")
+        logger.exception(e)
         return None
 
     query = 'SELECT time AS started, ' \
@@ -415,6 +420,7 @@ def import_from_plexwatch(database=None, table_name=None, import_ignore_interval
     logger.debug(u"PlexPy Importer :: PlexWatch data import complete.")
     import_users()
 
+
 def import_users():
     logger.debug(u"PlexPy Importer :: Importing PlexWatch Users...")
     monitor_db = database.MonitorDatabase()
@@ -426,5 +432,6 @@ def import_users():
     try:
         monitor_db.action(query)
         logger.debug(u"PlexPy Importer :: Users imported.")
-    except:
+    except Exception as e:
         logger.debug(u"PlexPy Importer :: Failed to import users.")
+        logger.exception(e)

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,13 +18,13 @@ import threading
 import urllib
 from urlparse import urlparse
 
-import plexpy
 import common
 import database
 import helpers
 import http_handler
 import libraries
 import logger
+import plexpy
 import session
 import users
 

--- a/plexpy/request.py
+++ b/plexpy/request.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -13,17 +14,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-from bs4 import BeautifulSoup
+import collections
 from xml.dom import minidom
 
 import feedparser
-import collections
 import requests
+from bs4 import BeautifulSoup
 
+import logger
 import plexpy
 import plexpy.lock
-import logger
-
 
 # Dictionary with last request times, for rate limiting.
 last_requests = collections.defaultdict(int)
@@ -210,7 +210,9 @@ def server_message(response):
     if "text/html" in response.headers.get("content-type"):
         try:
             soup = BeautifulSoup(response.content, "html5lib")
-        except Exception:
+        except Exception as e:
+            logger.exception(u"Unhandled exception")
+            logger.exception(e)
             pass
 
         # Find body and cleanup common tags to grab content, which probably

--- a/plexpy/session.py
+++ b/plexpy/session.py
@@ -1,4 +1,5 @@
-﻿#  This file is part of PlexPy.
+﻿# coding=utf-8
+#  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -34,12 +35,14 @@ def get_session_info():
     except AttributeError as e:
         return _session
 
+
 def get_session_user():
     """
     Returns the user_id for the current logged in session
     """
     _session = get_session_info()
     return _session['user'] if _session and _session['user'] else None
+
 
 def get_session_user_id():
     """
@@ -48,12 +51,14 @@ def get_session_user_id():
     _session = get_session_info()
     return str(_session['user_id']) if _session and _session['user_id'] else None
 
+
 def get_session_shared_libraries():
     """
     Returns a tuple of section_id for the current logged in session
     """
     user_details = users.Users().get_details(user_id=get_session_user_id())
     return tuple(str(s) for s in user_details['shared_libraries'])
+
 
 def get_session_library_filters():
     """
@@ -65,6 +70,7 @@ def get_session_library_filters():
     """
     filters = users.Users().get_filters(user_id=get_session_user_id())
     return filters
+
 
 def get_session_library_filters_type(filters, media_type=None):
     """
@@ -90,6 +96,7 @@ def get_session_library_filters_type(filters, media_type=None):
 
     return content_rating, tuple(f.lower() for f in labels)
 
+
 def allow_session_user(user_id):
     """
     Returns True or False if the user_id is allowed for the current logged in session
@@ -99,6 +106,7 @@ def allow_session_user(user_id):
         return False
     return True
 
+
 def allow_session_library(section_id):
     """
     Returns True or False if the section_id is allowed for the current logged in session
@@ -107,6 +115,7 @@ def allow_session_library(section_id):
     if session_library_ids and str(section_id) not in session_library_ids:
         return False
     return True
+
 
 def friendly_name_to_username(list_of_dicts):
     """
@@ -121,6 +130,7 @@ def friendly_name_to_username(list_of_dicts):
                 d['friendly_name'] = session_user
 
     return list_of_dicts
+
 
 def filter_session_info(list_of_dicts, filter_key=None):
     """
@@ -137,13 +147,13 @@ def filter_session_info(list_of_dicts, filter_key=None):
     list_of_dicts = friendly_name_to_username(list_of_dicts)
 
     if filter_key == 'user_id' and session_user_id:
-        return [d for d in list_of_dicts if str(d.get('user_id','')) == session_user_id]
+        return [d for d in list_of_dicts if str(d.get('user_id', '')) == session_user_id]
 
     elif filter_key == 'section_id' and session_library_ids:
         new_list_of_dicts = []
 
         for d in list_of_dicts:
-            if str(d.get('section_id','')) not in session_library_ids:
+            if str(d.get('section_id', '')) not in session_library_ids:
                 continue
 
             if d.get('media_type'):
@@ -172,6 +182,7 @@ def filter_session_info(list_of_dicts, filter_key=None):
         return new_list_of_dicts
 
     return list_of_dicts
+
 
 def mask_session_info(list_of_dicts, mask_metadata=True):
     """
@@ -217,20 +228,22 @@ def mask_session_info(list_of_dicts, mask_metadata=True):
     for d in list_of_dicts:
         if session_user_id and not (str(d.get('user_id')) == session_user_id or d.get('user') == session_user):
             for k, v in keys_to_mask.iteritems():
-                if k in d: d[k] = keys_to_mask[k]
+                if k in d:
+                    d[k] = keys_to_mask[k]
 
         if not mask_metadata:
             continue
 
-        if str(d.get('section_id','')) not in session_library_ids:
+        if str(d.get('section_id', '')) not in session_library_ids:
             for k, v in metadata_to_mask.iteritems():
-                if k in d: d[k] = metadata_to_mask[k]
+                if k in d:
+                    d[k] = metadata_to_mask[k]
             continue
 
         media_type = d.get('media_type')
         if media_type:
             f_content_rating, f_labels = get_session_library_filters_type(session_library_filters,
-                                                                      media_type=d['media_type'])
+                                                                          media_type=d['media_type'])
 
             d_content_rating = d.get('content_rating', '')
             d_labels = tuple(f.lower() for f in d.get('labels', ()))
@@ -248,6 +261,7 @@ def mask_session_info(list_of_dicts, mask_metadata=True):
                     continue
 
             for k, v in metadata_to_mask.iteritems():
-                if k in d: d[k] = metadata_to_mask[k]
+                if k in d:
+                    d[k] = metadata_to_mask[k]
 
     return list_of_dicts

--- a/plexpy/users.py
+++ b/plexpy/users.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,10 +14,10 @@
 #  You should have received a copy of the GNU General Public License
 #  along with PlexPy.  If not, see <http://www.gnu.org/licenses/>.
 
-import httpagentparser
 import time
 
-import plexpy
+import httpagentparser
+
 import common
 import database
 import datatables

--- a/plexpy/versioncheck.py
+++ b/plexpy/versioncheck.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -19,8 +20,8 @@ import re
 import subprocess
 import tarfile
 
-import plexpy
 import logger
+import plexpy
 import request
 import version
 
@@ -60,7 +61,7 @@ def runGit(args):
         elif output:
             break
 
-    return (output, err)
+    return output, err
 
 
 def getVersion():
@@ -137,7 +138,8 @@ def checkGithub(auto_update=False):
     # Get the latest version available from github
     logger.info('Retrieving latest version information from GitHub')
     url = 'https://api.github.com/repos/%s/plexpy/commits/%s' % (plexpy.CONFIG.GIT_USER, plexpy.CONFIG.GIT_BRANCH)
-    if plexpy.CONFIG.GIT_TOKEN: url = url + '?access_token=%s' % plexpy.CONFIG.GIT_TOKEN
+    if plexpy.CONFIG.GIT_TOKEN:
+        url += '?access_token=%s' % plexpy.CONFIG.GIT_TOKEN
     version = request.request_json(url, timeout=20, validator=lambda x: type(x) == dict)
 
     if version is None:
@@ -158,7 +160,8 @@ def checkGithub(auto_update=False):
 
     logger.info('Comparing currently installed version with latest GitHub version')
     url = 'https://api.github.com/repos/%s/plexpy/compare/%s...%s' % (plexpy.CONFIG.GIT_USER, plexpy.LATEST_VERSION, plexpy.CURRENT_VERSION)
-    if plexpy.CONFIG.GIT_TOKEN: url = url + '?access_token=%s' % plexpy.CONFIG.GIT_TOKEN
+    if plexpy.CONFIG.GIT_TOKEN:
+        url += '?access_token=%s' % plexpy.CONFIG.GIT_TOKEN
     commits = request.request_json(url, timeout=20, whitelist_status_code=404, validator=lambda x: type(x) == dict)
 
     if commits is None:
@@ -178,7 +181,7 @@ def checkGithub(auto_update=False):
         url = 'https://api.github.com/repos/%s/plexpy/releases/latest' % plexpy.CONFIG.GIT_USER
         release = request.request_json(url, timeout=20, whitelist_status_code=404, validator=lambda x: type(x) == dict)
         plexpy.NOTIFY_QUEUE.put({'notify_action': 'on_plexpyupdate', 'plexpy_download_info': release,
-                                    'plexpy_update_commit': plexpy.LATEST_VERSION, 'plexpy_update_behind': plexpy.COMMITS_BEHIND})
+                                'plexpy_update_commit': plexpy.LATEST_VERSION, 'plexpy_update_behind': plexpy.COMMITS_BEHIND})
 
         if auto_update:
             logger.info('Running automatic update.')
@@ -332,7 +335,7 @@ def read_changelog(latest_only=False):
                     prev_level = line_level
 
                 elif line.strip() == '' and prev_level:
-                    output += '</ul>' * (prev_level)
+                    output += '</ul>' * prev_level
                     prev_level = 0
 
         return output

--- a/plexpy/web_socket.py
+++ b/plexpy/web_socket.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,11 +22,11 @@ import time
 
 import websocket
 
-import plexpy
 import activity_handler
 import activity_pinger
 import activity_processor
 import logger
+import plexpy
 
 name = 'websocket'
 opcode_data = (websocket.ABNF.OPCODE_TEXT, websocket.ABNF.OPCODE_BINARY)

--- a/plexpy/webauth.py
+++ b/plexpy/webauth.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -18,22 +19,22 @@
 # Form based authentication for CherryPy. Requires the
 # Session tool to be loaded.
 
+import re
 from cgi import escape
 from datetime import datetime, timedelta
-import re
 
 import cherrypy
 from hashing_passwords import check_hash
 
-import plexpy
 import logger
+import plexpy
 import plextv
 from plexpy.database import MonitorDatabase
-from plexpy.users import Users
 from plexpy.plextv import PlexTV
-
+from plexpy.users import Users
 
 SESSION_KEY = '_cp_username'
+
 
 def user_login(username=None, password=None):
     if not username or not password:
@@ -88,7 +89,6 @@ def user_login(username=None, password=None):
         logger.warn(u"PlexPy WebAuth :: Unable to retrieve Plex.tv user token for user '%s'." % username)
         return None
 
-    return None
 
 def check_credentials(username, password, admin_login='0'):
     """Verifies credentials for username and password.
@@ -103,7 +103,8 @@ def check_credentials(username, password, admin_login='0'):
         return True, u'guest'
     else:
         return False, None
-    
+
+
 def check_auth(*args, **kwargs):
     """A tool that looks in config for 'auth.require'. If found and it
     is not None, a login is required and the entry is evaluated as a list of
@@ -120,7 +121,8 @@ def check_auth(*args, **kwargs):
                     raise cherrypy.HTTPRedirect(plexpy.HTTP_ROOT)
         else:
             raise cherrypy.HTTPRedirect(plexpy.HTTP_ROOT + "auth/logout")
-    
+
+
 def requireAuth(*conditions):
     """A decorator that appends conditions to the auth.require config
     variable."""
@@ -147,11 +149,12 @@ def member_of(groupname):
         return cherrypy.request.login == plexpy.CONFIG.HTTP_USERNAME and groupname == 'admin'
     return check
 
+
 def name_is(reqd_username):
     return lambda: reqd_username == cherrypy.request.login
 
-# These might be handy
 
+# These might be handy
 def any_of(*conditions):
     """Returns True if any of the conditions match"""
     def check():
@@ -160,6 +163,7 @@ def any_of(*conditions):
                 return True
         return False
     return check
+
 
 # By default all conditions are required, but this might still be
 # needed if you want to use it inside of an any_of(...) condition

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1,4 +1,5 @@
-﻿# This file is part of PlexPy.
+﻿# coding=utf-8
+# This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,14 +22,12 @@ import shutil
 import threading
 
 import cherrypy
-from cherrypy.lib.static import serve_file, serve_download
 from cherrypy._cperror import NotFound
-
+from cherrypy.lib.static import serve_download, serve_file
 from hashing_passwords import make_hash
-from mako.lookup import TemplateLookup
 from mako import exceptions
+from mako.lookup import TemplateLookup
 
-import plexpy
 import common
 import config
 import database
@@ -41,17 +40,18 @@ import log_reader
 import logger
 import notification_handler
 import notifiers
-import plextv
 import plexivity_import
+import plexpy
+import plextv
 import plexwatch_import
 import pmsconnect
 import users
 import versioncheck
 import web_socket
 from plexpy.api2 import API2
-from plexpy.helpers import checked, addtoapi, get_ip, create_https_certificates, build_datatables_json
-from plexpy.session import get_session_info, get_session_user_id, allow_session_user, allow_session_library
-from plexpy.webauth import AuthController, requireAuth, member_of, name_is
+from plexpy.helpers import addtoapi, build_datatables_json, checked, create_https_certificates, get_ip
+from plexpy.session import allow_session_library, allow_session_user, get_session_info, get_session_user_id
+from plexpy.webauth import AuthController, member_of, requireAuth
 
 
 def serve_template(templatename, **kwargs):
@@ -86,7 +86,6 @@ class WebInterface(object):
             raise cherrypy.HTTPRedirect(plexpy.HTTP_ROOT + "home")
         else:
             raise cherrypy.HTTPRedirect(plexpy.HTTP_ROOT + "welcome")
-
 
     ##### Welcome #####
 
@@ -162,7 +161,6 @@ class WebInterface(object):
 
         if servers:
             return servers
-
 
     ##### Home #####
 
@@ -340,7 +338,6 @@ class WebInterface(object):
             return {'result': 'success', 'message': 'Temporary sessions flushed.'}
         else:
             return {'result': 'error', 'message': 'Flush sessions failed.'}
-
 
     ##### Libraries #####
 
@@ -4617,9 +4614,9 @@ class WebInterface(object):
     @requireAuth()
     def get_plexpy_url(self, **kwargs):
         if plexpy.CONFIG.ENABLE_HTTPS:
-           scheme = 'https' 
+            scheme = 'https'
         else:
-           scheme = 'http'
+            scheme = 'http'
 
         if plexpy.CONFIG.HTTP_HOST == '0.0.0.0':
             import socket

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  This file is part of PlexPy.
 #
 #  PlexPy is free software: you can redistribute it and/or modify
@@ -16,9 +17,10 @@
 import os
 import sys
 
-import plexpy
 import cherrypy
+
 import logger
+import plexpy
 import webauth
 from plexpy.helpers import create_https_certificates
 from plexpy.webserve import WebInterface
@@ -34,7 +36,7 @@ def initialize(options):
     if enable_https:
         # If either the HTTPS certificate or key do not exist, try to make self-signed ones.
         if plexpy.CONFIG.HTTPS_CREATE_CERT and \
-            (not (https_cert and os.path.exists(https_cert)) or not (https_key and os.path.exists(https_key))):
+                (not (https_cert and os.path.exists(https_cert)) or not (https_key and os.path.exists(https_key))):
             if not create_https_certificates(https_cert, https_key):
                 logger.warn(u"PlexPy WebStart :: Unable to create certificate and key. Disabling HTTPS")
                 enable_https = False
@@ -190,7 +192,7 @@ def initialize(options):
             'tools.auth.on': False,
             'tools.sessions.on': False
         },
-        #'/pms_image_proxy': {
+        # '/pms_image_proxy': {
         #    'tools.staticdir.on': True,
         #    'tools.staticdir.dir': os.path.join(plexpy.CONFIG.CACHE_DIR, 'images'),
         #    'tools.caching.on': True,
@@ -200,7 +202,7 @@ def initialize(options):
         #    'tools.expires.secs': 60 * 60 * 24 * 30,  # 30 days
         #    'tools.auth.on': False,
         #    'tools.sessions.on': False
-        #},
+        # },
         '/favicon.ico': {
             'tools.staticfile.on': True,
             'tools.staticfile.filename': os.path.abspath(os.path.join(plexpy.PROG_DIR, 'data/interfaces/default/images/favicon.ico')),


### PR DESCRIPTION
Hello!

I am reading though your code as an exercise and made some small edits along the way.  Almost all of this is PEP8 related and generated by my linter.  No behavior should have changed at all.  The biggest changes I made were:

1. Imports have been organized and trimmed down
2. Catchall exceptions are now being logged. 
3. Mixed tabs and spaces have been converted to spaces
4. Unnecessary escape characters were removed.
5. Unreachable `return` statements removed
6. Unreachable `except` clauses removed when they are redundant as well
7. Whitespace

After reviewing the code I think it would be very possible to get this working in Python3 with little trouble.  Any interest in some Pull Requests to that end?