### PR TITLE
session_id notification type

### DIFF
--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -383,7 +383,7 @@ def dbcheck():
     # sessions table :: This is a temp table that logs currently active sessions
     c_db.execute(
         'CREATE TABLE IF NOT EXISTS sessions (id INTEGER PRIMARY KEY AUTOINCREMENT, session_key INTEGER, '
-        'transcode_key TEXT, rating_key INTEGER, section_id INTEGER, media_type TEXT, started INTEGER, stopped INTEGER, '
+        'transcode_key TEXT, session_id TEXT, rating_key INTEGER, section_id INTEGER, media_type TEXT, started INTEGER, stopped INTEGER, '
         'paused_counter INTEGER DEFAULT 0, state TEXT, user_id INTEGER, user TEXT, friendly_name TEXT, '
         'ip_address TEXT, machine_id TEXT, player TEXT, platform TEXT, title TEXT, parent_title TEXT, '
         'grandparent_title TEXT, full_title TEXT, media_index INTEGER, parent_media_index INTEGER, '
@@ -643,6 +643,15 @@ def dbcheck():
         logger.debug(u"Altering database. Updating database table sessions.")
         c_db.execute(
             'ALTER TABLE sessions ADD COLUMN write_attempts INTEGER DEFAULT 0'
+        )
+
+    # Upgrade sessions table from earlier versions
+    try:
+        c_db.execute('SELECT session_id FROM sessions')
+    except sqlite3.OperationalError:
+        logger.debug(u"Altering database. Updating database table sessions.")
+        c_db.execute(
+            'ALTER TABLE sessions ADD COLUMN session_id TEXT'
         )
 
     # Upgrade sessions table from earlier versions

--- a/plexpy/activity_processor.py
+++ b/plexpy/activity_processor.py
@@ -38,6 +38,7 @@ class ActivityProcessor(object):
         if session:
             values = {'session_key': session['session_key'],
                       'transcode_key': session['transcode_key'],
+                      'session_id': session['session_id'],
                       'section_id': session['section_id'],
                       'rating_key': session['rating_key'],
                       'media_type': session['media_type'],

--- a/plexpy/notification_handler.py
+++ b/plexpy/notification_handler.py
@@ -801,6 +801,7 @@ def build_notify_text(session=None, timeline=None, notify_action=None, agent_id=
                         'transcode_audio_channels': session.get('transcode_audio_channels',''),
                         'session_key': session.get('session_key',''),
                         'transcode_key': session.get('transcode_key',''),
+                        'session_id': session.get('session_id',''),
                         'user_id': session.get('user_id',''),
                         'machine_id': session.get('machine_id',''),
                         # Metadata parameters

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -1174,6 +1174,8 @@ class PmsConnect(object):
             height = helpers.get_xml_attr(media_info, 'height')
             duration = helpers.get_xml_attr(media_info, 'duration')
             progress = helpers.get_xml_attr(session, 'viewOffset')
+            session_xml = session.getElementsByTagName('Session')[0]
+            session_id = helpers.get_xml_attr(session_xml, 'id')
 
             if session.getElementsByTagName('TranscodeSession'):
                 transcode_session = session.getElementsByTagName('TranscodeSession')[0]
@@ -1242,6 +1244,7 @@ class PmsConnect(object):
 
             if helpers.get_xml_attr(session, 'type') == 'episode':
                 session_output = {'session_key': helpers.get_xml_attr(session, 'sessionKey'),
+                                  'session_id': session_id,
                                   'section_id': helpers.get_xml_attr(session, 'librarySectionID'),
                                   'media_index': helpers.get_xml_attr(session, 'index'),
                                   'parent_media_index': helpers.get_xml_attr(session, 'parentIndex'),
@@ -1307,6 +1310,7 @@ class PmsConnect(object):
             elif helpers.get_xml_attr(session, 'type') == 'movie':
                 session_output = {'session_key': helpers.get_xml_attr(session, 'sessionKey'),
                                   'section_id': helpers.get_xml_attr(session, 'librarySectionID'),
+                                  'session_id': session_id,
                                   'media_index': helpers.get_xml_attr(session, 'index'),
                                   'parent_media_index': helpers.get_xml_attr(session, 'parentIndex'),
                                   'art': helpers.get_xml_attr(session, 'art'),
@@ -1369,6 +1373,7 @@ class PmsConnect(object):
 
             elif helpers.get_xml_attr(session, 'type') == 'clip':
                 session_output = {'session_key': helpers.get_xml_attr(session, 'sessionKey'),
+                                  'session_id': session_id,
                                   'section_id': helpers.get_xml_attr(session, 'librarySectionID'),
                                   'media_index': helpers.get_xml_attr(session, 'index'),
                                   'parent_media_index': helpers.get_xml_attr(session, 'parentIndex'),


### PR DESCRIPTION
Added session_id as notification option. This allows for scripts to kill a stream using the method used here:
http://forums.plex.tv/discussion/259921/kill-a-stream-button