### PR TITLE
Change amount of months in Graphs > Play Totals > Plays by Month

### DIFF
--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -2833,6 +2833,14 @@ div[id^='media_info_child'] div[id^='media_info_child'] div.dataTables_scrollHea
     width: 75px;
     height: 34px;
 }
+#months-selection label {
+    margin-bottom: 0;
+}
+#graph-months {
+	margin: 0;
+	width: 75px;
+	height: 34px;
+}
 .card-sortable {
     height: 36px;
     padding: 0 20px 0 0;

--- a/data/interfaces/default/graphs.html
+++ b/data/interfaces/default/graphs.html
@@ -42,6 +42,11 @@
                     <input type="number" name="graph-days" id="graph-days" value="${config['graph_days']}" min="1" /> days
                 </label>
             </div>
+            <div class="btn-group" id="months-selection">
+                <label>
+                    <input type="number" name="graph-months" id="graph-months" value="${config['graph_months']}" min="1" /> months
+                </label>
+			</div>
         </div>
     </div>
     <div class='table-card-back'>
@@ -226,7 +231,7 @@
             % endif
                 <div class="row">
                     <div class="col-md-12">
-                        <h4><i class="fa fa-calendar"></i> Plays by Month <small>Last 12 months</small></h4>
+                        <h4><i class="fa fa-calendar"></i> Plays by Month <small>Last <span class="months">12</span> months</small></h4>
                         <p class="help-block">
                             The combined total of tv, movies, and music by month.
                         </p>
@@ -318,9 +323,11 @@
         // Initial values for graph from config
         var yaxis = "${config['graph_type']}";
         var current_range = ${config['graph_days']};
+        var current_month_range = ${config['graph_months']};
         var current_tab = "${'#' + config['graph_tab']}";
         
         $('.days').html(current_range);
+        $('.months').html(current_month_range);
         
         // Load user ids and names (for the selector)
         $.ajax({
@@ -352,6 +359,7 @@
 
         function loadGraphsTab1(time_range, yaxis) {
             $('#days-selection').show();
+            $('#months-selection').hide();
 
             setGraphFormat(yaxis);
 
@@ -442,6 +450,7 @@
 
         function loadGraphsTab2(time_range, yaxis) {
             $('#days-selection').show();
+            $('#months-selection').hide();
 
             setGraphFormat(yaxis);
 
@@ -525,15 +534,16 @@
             });
         }
 
-        function loadGraphsTab3(yaxis) {
+        function loadGraphsTab3(time_range, yaxis) {
             $('#days-selection').hide();
+            $('#months-selection').show();
 
             setGraphFormat(yaxis);
 
             $.ajax({
                 url: "get_plays_per_month",
                 type: 'get',
-                data: { y_axis: yaxis, user_id: selected_user_id },
+                data: { time_range: time_range, y_axis: yaxis, user_id: selected_user_id },
                 dataType: "json",
                 success: function(data) {
                     if (yaxis === 'duration') { dataSecondsToHours(data); }
@@ -549,7 +559,7 @@
         // Set initial state
         if (current_tab == '#tabs-1') { loadGraphsTab1(current_range, yaxis); }
         if (current_tab == '#tabs-2') { loadGraphsTab2(current_range, yaxis); }
-        if (current_tab == '#tabs-3') { loadGraphsTab3(yaxis); }
+        if (current_tab == '#tabs-3') { loadGraphsTab3(current_month_range, yaxis); }
 
         // Tab1 opened
         $('#graph-tabs a[href="#tabs-1"]').on('shown.bs.tab', function (e) {
@@ -579,7 +589,7 @@
         $('#graph-tabs a[href="#tabs-3"]').on('shown.bs.tab', function (e) {
             e.preventDefault();
             current_tab = $(this).attr('href');
-            loadGraphsTab3(yaxis);
+            loadGraphsTab3(current_month_range, yaxis);
             $.ajax({
                 url: 'set_graph_config',
                 data: { graph_tab: current_tab.replace('#','') },
@@ -603,13 +613,29 @@
                 async: true
             });
         });
+        
+        // Month range changed
+        $('#graph-months').on('change', function() {
+            current_month_range = $(this).val();
+            if (current_month_range < 1) {
+                $(this).val(12);
+                current_month_range = 12;
+            }
+            if (current_tab == '#tabs-3') { loadGraphsTab3(current_month_range, yaxis); }
+            $('.months').html(current_month_range);
+            $.ajax({
+                url: 'set_graph_config',
+                data: { graph_months: current_month_range},
+                async: true
+            });
+        });
 
         // User changed
         $('#graph-user').on('change', function() {
             selected_user_id = $(this).val() || null;
             if (current_tab == '#tabs-1') { loadGraphsTab1(current_range, yaxis); }
             if (current_tab == '#tabs-2') { loadGraphsTab2(current_range, yaxis); }
-            if (current_tab == '#tabs-3') { loadGraphsTab3(yaxis); }
+            if (current_tab == '#tabs-3') { loadGraphsTab3(current_month_range, yaxis); }
         });
         
         // Y-axis changed
@@ -617,7 +643,7 @@
             yaxis = $('input[name=yaxis-options]:checked', '#yaxis-selection').val();
             if (current_tab == '#tabs-1') { loadGraphsTab1(current_range, yaxis); }
             if (current_tab == '#tabs-2') { loadGraphsTab2(current_range, yaxis); }
-            if (current_tab == '#tabs-3') { loadGraphsTab3(yaxis); }
+            if (current_tab == '#tabs-3') { loadGraphsTab3(current_month_range,yaxis); }
             $.ajax({
                 url: 'set_graph_config',
                 data: { graph_type: yaxis},

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -174,6 +174,7 @@ _CONFIG_DEFINITIONS = {
     'GIT_USER': (str, 'General', 'JonnyWong16'),
     'GRAPH_TYPE': (str, 'General', 'plays'),
     'GRAPH_DAYS': (int, 'General', 30),
+    'GRAPH_MONTHS': (int, 'General', 12),
     'GRAPH_TAB': (str, 'General', 'tabs-1'),
     'GROUP_HISTORY_TABLES': (int, 'General', 0),
     'GROWL_ENABLED': (int, 'Growl', 0),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1747,6 +1747,7 @@ class WebInterface(object):
         config = {
             "graph_type": plexpy.CONFIG.GRAPH_TYPE,
             "graph_days": plexpy.CONFIG.GRAPH_DAYS,
+            "graph_months": 12,
             "graph_tab": plexpy.CONFIG.GRAPH_TAB,
             "music_logging_enable": plexpy.CONFIG.MUSIC_LOGGING_ENABLE
         }
@@ -1755,13 +1756,15 @@ class WebInterface(object):
 
     @cherrypy.expose
     @requireAuth(member_of("admin"))
-    def set_graph_config(self, graph_type=None, graph_days=None, graph_tab=None, **kwargs):
+    def set_graph_config(self, graph_type=None, graph_days=None, graph_months=None, graph_tab=None, **kwargs):
         if graph_type:
             plexpy.CONFIG.__setattr__('GRAPH_TYPE', graph_type)
             plexpy.CONFIG.write()
         if graph_days:
             plexpy.CONFIG.__setattr__('GRAPH_DAYS', graph_days)
             plexpy.CONFIG.write()
+        if graph_months:
+            pass
         if graph_tab:
             plexpy.CONFIG.__setattr__('GRAPH_TAB', graph_tab)
             plexpy.CONFIG.write()
@@ -1908,7 +1911,7 @@ class WebInterface(object):
     @cherrypy.tools.json_out()
     @requireAuth()
     @addtoapi()
-    def get_plays_per_month(self, y_axis='plays', user_id=None, **kwargs):
+    def get_plays_per_month(self, time_range='12', y_axis='plays', user_id=None, **kwargs):
         """ Get graph data by month.
 
             ```
@@ -1916,7 +1919,7 @@ class WebInterface(object):
                 None
 
             Optional parameters:
-                time_range (str):       The number of days of data to return
+                time_range (str):       The number of months of data to return
                 y_axis (str):           "plays" or "duration"
                 user_id (str):          The user id to filter the data
 
@@ -1933,7 +1936,7 @@ class WebInterface(object):
             ```
         """
         graph = graphs.Graphs()
-        result = graph.get_total_plays_per_month(y_axis=y_axis, user_id=user_id)
+        result = graph.get_total_plays_per_month(time_range=time_range, y_axis=y_axis, user_id=user_id)
 
         if result:
             return result

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1747,7 +1747,7 @@ class WebInterface(object):
         config = {
             "graph_type": plexpy.CONFIG.GRAPH_TYPE,
             "graph_days": plexpy.CONFIG.GRAPH_DAYS,
-            "graph_months": 12,
+            "graph_months": plexpy.CONFIG.GRAPH_MONTHS,
             "graph_tab": plexpy.CONFIG.GRAPH_TAB,
             "music_logging_enable": plexpy.CONFIG.MUSIC_LOGGING_ENABLE
         }
@@ -1764,7 +1764,8 @@ class WebInterface(object):
             plexpy.CONFIG.__setattr__('GRAPH_DAYS', graph_days)
             plexpy.CONFIG.write()
         if graph_months:
-            pass
+            plexpy.CONFIG.__setattr__('GRAPH_MONTHS', graph_months)
+            plexpy.CONFIG.write()
         if graph_tab:
             plexpy.CONFIG.__setattr__('GRAPH_TAB', graph_tab)
             plexpy.CONFIG.write()


### PR DESCRIPTION
Added code to change the amount of months that the Graphs > Play Totals > Plays by Month will show. Currently the graph shows the last 12 months. This can now be changed into the last X months (similar to how you can change the amount of days for the Plays by Period and Stream Info graphs).

<img width="1434" alt="screen shot 2017-02-27 at 00 29 52" src="https://cloud.githubusercontent.com/assets/16807241/23344847/f2cc7cec-fc83-11e6-9177-ab994f3336e3.png">
