### PR TITLE
Start day of the week changeable

### DIFF
--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -119,6 +119,12 @@
                         </div>
                         <div class="checkbox">
                             <label>
+                                <input type="checkbox" id="week_start" name="week_start" value="1" ${config['week_start']}> Week starting on Monday
+                            </label>
+                            <p class="help-block">Default is Sunday. This is only relevant for the Play by day of week graph.</p>
+                        </div>
+                        <div class="checkbox">
+                            <label>
                                 <input type="checkbox" id="group_history_tables" name="group_history_tables" value="1" ${config['group_history_tables']}> Group Table and Watch Statistics History
                             </label>
                             <p class="help-block">Group successive play history by the same user as a single entry in the tables and watch statistics.</p>

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -565,6 +565,7 @@ _CONFIG_DEFINITIONS = {
     'UPDATE_LABELS': (int, 'General', 1),
     'VERIFY_SSL_CERT': (bool_int, 'Advanced', 1),
     'VIDEO_LOGGING_ENABLE': (int, 'Monitoring', 1),
+    'WEEK_START': (int, 'General', 0),
     'XBMC_ENABLED': (int, 'XBMC', 0),
     'XBMC_HOST': (str, 'XBMC', ''),
     'XBMC_PASSWORD': (str, 'XBMC', ''),

--- a/plexpy/graphs.py
+++ b/plexpy/graphs.py
@@ -169,7 +169,12 @@ class Graphs(object):
             logger.warn(u"PlexPy Graphs :: Unable to execute database query for get_total_plays_per_dayofweek: %s." % e)
             return None
 
-        days_list = ['Sunday', 'Monday', 'Tuesday', 'Wednesday',
+        week_start = plexpy.CONFIG.WEEK_START
+        if (week_start == 1):
+            days_list = ['Monday', 'Tuesday', 'Wednesday',
+                     'Thursday', 'Friday', 'Saturday', 'Sunday']
+        else:
+            days_list = ['Sunday', 'Monday', 'Tuesday', 'Wednesday',
                      'Thursday', 'Friday', 'Saturday']
 
         categories = []

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -2618,7 +2618,8 @@ class WebInterface(object):
             "git_token": plexpy.CONFIG.GIT_TOKEN,
             "imgur_client_id": plexpy.CONFIG.IMGUR_CLIENT_ID,
             "cache_images": checked(plexpy.CONFIG.CACHE_IMAGES),
-            "pms_version": plexpy.CONFIG.PMS_VERSION
+            "pms_version": plexpy.CONFIG.PMS_VERSION,
+            "week_start": checked(plexpy.CONFIG.WEEK_START)
         }
 
         return serve_template(templatename="settings.html", title="Settings", config=config, kwargs=kwargs)
@@ -2632,7 +2633,7 @@ class WebInterface(object):
         checked_configs = [
             "launch_browser", "enable_https", "https_create_cert", "api_enabled", "freeze_db", "check_github",
             "grouping_global_history", "grouping_user_history", "grouping_charts", "group_history_tables",
-            "pms_use_bif", "pms_ssl", "pms_is_remote", "home_stats_type",
+            "pms_use_bif", "pms_ssl", "pms_is_remote", "home_stats_type", "week_start",
             "movie_notify_enable", "tv_notify_enable", "music_notify_enable", "monitoring_use_websocket",
             "refresh_libraries_on_startup", "refresh_users_on_startup",
             "ip_logging_enable", "movie_logging_enable", "tv_logging_enable", "music_logging_enable",


### PR DESCRIPTION
Option in general settings to change the start day of the week to Monday (instead of the default of Sunday). This is only relevant for the Graph : Play by day of week.

Feathub issue : http://feathub.com/JonnyWong16/plexpy/+15

![days-1](https://cloud.githubusercontent.com/assets/16807241/23374505/df773d8e-fd24-11e6-9b16-8d1957425923.png)

![days-2](https://cloud.githubusercontent.com/assets/16807241/23374504/df7734ba-fd24-11e6-9cff-73e180bb4f4e.png)


