### PR TITLE
Wrap history footer text

### DIFF
--- a/data/interfaces/default/css/plexpy.css
+++ b/data/interfaces/default/css/plexpy.css
@@ -404,6 +404,9 @@ textarea.form-control:focus {
     background-color: #fff;
     transition: background-color .3s;
 }
+#history_table_info {
+    white-space: normal;
+}
 .pagination > li > a,
 .pagination > li > span {
     position: relative;
@@ -590,14 +593,14 @@ a .users-poster-face:hover {
 .dashboard-instance.hover .dashboard-activity-poster-info-bar {
     opacity: 1;
 }
-.dashboard-instance.hover .dashboard-activity-progress-bar { 
-	height: 14px; 
+.dashboard-instance.hover .dashboard-activity-progress-bar {
+	height: 14px;
 	transform-origin: top;
     transition: all .2s ease;
 	border-radius: 0px 0px 3px 3px;
 }
-.dashboard-instance.hover .bar { 
-	height: 14px; 
+.dashboard-instance.hover .bar {
+	height: 14px;
     max-width: 100%;
 	transform-origin: top;
     transition: all .2s ease;
@@ -607,8 +610,8 @@ a .users-poster-face:hover {
     background-image: -moz-linear-gradient(left,rgba(0,0,0,0.25) 0%,rgba(0,0,0,0) 50px);
     background-image: linear-gradient(to left,rgba(0,0,0,0.25) 0%,rgba(0,0,0,0) 50px);
 }
-.dashboard-instance.hover .bufferbar { 
-	height: 14px; 
+.dashboard-instance.hover .bufferbar {
+	height: 14px;
     max-width: 100%;
 	transform-origin: top;
     transition: all .2s ease;
@@ -618,7 +621,7 @@ a .users-poster-face:hover {
     background-image: -moz-linear-gradient(left,rgba(0,0,0,0.25) 0%,rgba(0,0,0,0) 50px);
     background-image: linear-gradient(to left,rgba(0,0,0,0.25) 0%,rgba(0,0,0,0) 50px);
 }
-.dashboard-instance.hover .dashboard-activity-metadata-wrapper { 
+.dashboard-instance.hover .dashboard-activity-metadata-wrapper {
 	margin-top: 11px;
 	transform-origin: top;
     transition: all .2s ease;
@@ -2662,8 +2665,8 @@ a .home-platforms-list-cover-face:hover
     background-clip: padding-box;
 }
 
-@media only screen 
-  and (min-device-width: 300px) 
+@media only screen
+  and (min-device-width: 300px)
   and (max-device-width: 450px) {
     .home-platforms-instance {
         width: calc(100% - 20px);
@@ -2695,7 +2698,7 @@ table.display tr.shown + tr .pagination > .active > a,
 table.display tr.shown + tr .pagination > .active > a:hover {
     color: #fff;
 }
-table.display tr.shown + tr table[id^='history_child'] td:hover a, 
+table.display tr.shown + tr table[id^='history_child'] td:hover a,
 table.display tr.shown + tr table[id^='media_info_child'] > tr > td:hover a,
 table.display tr.shown + tr table[id^='media_info_child'] tr.shown + tr table[id^='media_info_child'] td:hover a {
     color: #cc7b19;

--- a/plexpy/api2.py
+++ b/plexpy/api2.py
@@ -407,7 +407,7 @@ General optional parameters:
         data = None
         apikey = hashlib.sha224(str(random.getrandbits(256))).hexdigest()[0:32]
         if plexpy.CONFIG.HTTP_USERNAME and plexpy.CONFIG.HTTP_PASSWORD:
-            if username == plexpy.HTTP_USERNAME and password == plexpy.CONFIG.HTTP_PASSWORD:
+            if username == plexpy.CONFIG.HTTP_USERNAME and password == plexpy.CONFIG.HTTP_PASSWORD:
                 if plexpy.CONFIG.API_KEY:
                     data = plexpy.CONFIG.API_KEY
                 else:


### PR DESCRIPTION
Fixes issue #943 

Apologies if I didn't do this right - this is my first PR for an open source project!

The CSS class "dataTables_info" has `white-space: nowrap;`, which is causing the issue.  I'm not sure where else this class is used, so I targeted the `#history_table_info` id instead.

The bootstrap grid classes are unaffected, so extra data will still be hidden as the viewport narrows.

Trailing spaces were also removed to clean this file up!

## Before 
![before](https://cloud.githubusercontent.com/assets/505670/24335593/298a1d86-1235-11e7-8f3f-3d2c2846cbe2.png)
## After
![after](https://cloud.githubusercontent.com/assets/505670/24335594/2b736418-1235-11e7-831f-860e7e3c4244.png)

