### PR TITLE
Remove nowrap for footer text on history page

### DIFF
--- a/data/interfaces/default/css/jquery.dataTables.css
+++ b/data/interfaces/default/css/jquery.dataTables.css
@@ -292,6 +292,7 @@ table.dataTable td {
   clear: both;
   float: left;
   padding-top: 0.755em;
+  white-space: normal;
 }
 .dataTables_wrapper .dataTables_paginate {
   float: right;


### PR DESCRIPTION
Fixes issue #943 

Making changes to `.dataTables_info` as [requested](https://github.com/JonnyWong16/plexpy/pull/1006#issuecomment-289323464).

The bootstrap grid classes are unaffected, so extra data will still be hidden as the viewport narrows.

## Before 
![before](https://cloud.githubusercontent.com/assets/505670/24335593/298a1d86-1235-11e7-8f3f-3d2c2846cbe2.png)
## After
![after](https://cloud.githubusercontent.com/assets/505670/24335594/2b736418-1235-11e7-831f-860e7e3c4244.png)
