### PR TITLE
Add support for looking up IPv6 addresses

### DIFF
--- a/data/interfaces/default/js/script.js
+++ b/data/interfaces/default/js/script.js
@@ -272,8 +272,15 @@ function isPrivateIP(ip_address) {
             return true;
         }
         return false;
+    } else if (ip_address.indexOf(":") > -1){
+        var parts = ip_address.split(":");
+        // basic checking for link-local or unique local
+        if (parts[0] === 'fe80' || parts[0] === 'fc00' || parts[0] === 'fd00') {
+          return true;
+        }
+        return false;
     } else {
-        return true;
+      return true;
     }
 }
 

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1719,7 +1719,10 @@ class WebInterface(object):
         try:
             socket.inet_aton(ip_address)
         except socket.error:
-            ip_address = None
+            try:
+                socket.inet_pton(socket.AF_INET6, ip_address)
+            except socket.error:
+                ip_address = None
 
         return serve_template(templatename="ip_address_modal.html", title="IP Address Details", data=ip_address)
 


### PR DESCRIPTION
Small changes to get_ip_address_details endpoint and isPrivateIP JS function to validate an IPv6 address correctly. geoip2 and ipwhois already support IPv6 addresses as-is.