### PR TITLE
UI Bug: Prevent autofill of http_password field

### DIFF
--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -499,7 +499,7 @@
                             <label for="http_password">HTTP Password</label>
                             <div class="row">
                                 <div class="col-md-4">
-                                    <input type="password" class="form-control auth-settings" id="http_password" name="http_password" value="${config['http_password']}" size="30">
+                                    <input type="password" autocomplete="new-password" class="form-control auth-settings" id="http_password" name="http_password" value="${config['http_password']}" size="30">
                                 </div>
                                 <div id="http_hash_password_error" class="alert alert-danger settings-alert" role="alert"></div>
                             </div>


### PR DESCRIPTION
### Scenario
-  PlexPy is configured without username/password auth
-  Browser-based password manager has saved credentials for the domain PlexPy is serving on
-  User visits the settings page but doesn't intend to make any changes.

### Problem  
-  Browser-based password manager autofills the http_username and http_password fields as soon as the settings page is opened;  any save writes this password to config and prompts users to restart
-  If saved accidentally, PlexPy will start prompting for auth

### Solution
-  Setting `autocomplete="new-password"` on an empty password field prevents password managers from filling it in.  It doesn't really matter if http_username is autofilled and saved since that doesn't change auth behaviour or prompt users to restart.
-  Alternatively, add an option list for "no auth / form auth / basic auth" and add/remove input fields via JS when relevant options are selected.

