### PR TITLE
Replace which with command in Plexpy.py

### DIFF
--- a/PlexPy.py
+++ b/PlexPy.py
@@ -1,7 +1,7 @@
 #!/bin/sh
-''''which python    >/dev/null 2>&1 && exec python    "$0" "$@" # '''
-''''which python2   >/dev/null 2>&1 && exec python2   "$0" "$@" # '''
-''''which python2.7 >/dev/null 2>&1 && exec python2.7 "$0" "$@" # '''
+''''command -v python    >/dev/null 2>&1 && exec python    "$0" "$@" # '''
+''''command -v python2   >/dev/null 2>&1 && exec python2   "$0" "$@" # '''
+''''command -v python2.7 >/dev/null 2>&1 && exec python2.7 "$0" "$@" # '''
 ''''exec echo "Error: Python not found!" # '''
 
 # -*- coding: utf-8 -*-


### PR DESCRIPTION
Replaces `which` with `command -v` to check for the python executable. 
Came across this since `which` is not available on a Centos 7 LXC container. Even with Python installed running Plexpy resulted in `Error: Python not found!` because of the missing which package.

Command is POSIX compatible (more info [see](https://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script))
I [tested my changes](https://travis-ci.org/wilmardo/ansible-role-plex/builds/305442254) on the most popular platforms by adapting my Ansible role. It pulled my branch instead of the plexpy master and the tests complete nicely (which test that the webinterface is functioning).

