### PR TITLE
Fix OpenSSL SSL.ConnectionType deprecation warning

### DIFF
--- a/lib/cherrypy/wsgiserver/ssl_pyopenssl.py
+++ b/lib/cherrypy/wsgiserver/ssl_pyopenssl.py
@@ -39,6 +39,10 @@ from cherrypy import wsgiserver
 try:
     from OpenSSL import SSL
     from OpenSSL import crypto
+    if hasattr(SSL, 'Connection'):
+        SSLConnectionType = SSL.Connection
+    else:
+        SSLConnectionType = SSL.ConnectionType
 except ImportError:
     SSL = None
 
@@ -244,7 +248,7 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
         return ssl_environ
 
     def makefile(self, sock, mode='r', bufsize=-1):
-        if SSL and isinstance(sock, SSL.ConnectionType):
+        if SSL and isinstance(sock, SSLConnectionType):
             timeout = sock.gettimeout()
             f = SSL_fileobject(sock, mode, bufsize)
             f.ssl_timeout = timeout


### PR DESCRIPTION
This patches the vendored cherrypy lib to work around a deprecation warning in pyOpenSSL 17.1.0 and later by checking and using the `SSL.Connection` class if available and falling back to `SSL.ConnectionType` otherwise.

Fixes #1142