### PR TITLE
Make Tautulli logo clickable again

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -65,7 +65,7 @@
                     <span class="icon-bar"></span>
                 </button>
                 <a class="navbar-brand svg" href="home">
-                    <object data="${http_root}images/logo-tautulli.svg" type="image/svg+xml" style="height: 45px;"></object>
+                    <img src="${http_root}images/logo-tautulli.svg" type="image/svg+xml" style="height: 45px;"/>
                 </a>
             </div>
             <div class="collapse navbar-collapse navbar-right" id="navbar-collapse-1">


### PR DESCRIPTION
Clicking an `object` inside an `a` doesn't work, but clicking an `img` does. It's better to display a `.svg` file with `img` tag in any case.

https://caniuse.com/#feat=svg-img