### PR TITLE
Fix {server_uptime} tag

### DIFF
--- a/plexpy/notification_handler.py
+++ b/plexpy/notification_handler.py
@@ -550,8 +550,8 @@ def build_notify_text(session=None, timeline=None, notify_action=None, agent_id=
     server_times = plex_tv.get_server_times()
 
     if server_times:
-        updated_at = server_times['updated_at']
-        server_uptime = helpers.human_duration(int(time.time() - helpers.cast_to_int(updated_at)))
+        created_at = server_times['created_at']
+        server_uptime = helpers.human_duration(int(time.time() - helpers.cast_to_int(created_at)))
     else:
         logger.error(u"PlexPy NotificationHandler :: Unable to retrieve server uptime.")
         server_uptime = 'N/A'


### PR DESCRIPTION
Bug #753: part-fix. The `server.xml` endpoint returns two attributes:
```
createdAt="1497562639" updatedAt="1520351529"
```

Plexpy uses `updatedAt` for which it is unclear as to what event it references.

`createdAt` is _closer_ to the actual "server uptime" in that it seems to be the timestamp when the server was created. As of right now the `createdAt` value corresponds to roughly when I first installed Plex (from memory).

`{server_uptime}` is described in such a way it appears it should return what `uptime` returns when run on the console of the Plex server's host OS, but that value doesn't appear to be exposed anywhere by the Plex API that I can tell.