### PR TITLE
Adding the notice/disclaimer to the login page

### DIFF
--- a/data/interfaces/default/login.html
+++ b/data/interfaces/default/login.html
@@ -58,6 +58,9 @@
                                 <input type="password" id="password" name="password" class="form-control">
                             </div>
                             <div class="form-footer">
+                              <div id="notice" class="alert" style="text-align: center; color: red;">
+                                NOTICE: Your login details are being securely checked against plex.tv API.
+                              </div>
                                 <div class="remember-group">
                                     <label class="control-label">
                                         <input type="checkbox" id="remember_me" name="remember_me" title="for 30 days" value="1" checked="checked" /> Remember me


### PR DESCRIPTION
I'm sorry for the PR's I messed up, but now it's not messed up. :smile: 

This PR is about a notice to let users know that their information is securely checked against the API rather than having no indication of that anywhere.

Unfamiliar and users who have guest access will most likely appreciate it. Feel free to suggest edits if it should be done some other way, or way it's said.

