### PR TITLE
Add show_name_slug to available parameters

### DIFF
--- a/plexpy/notification_handler.py
+++ b/plexpy/notification_handler.py
@@ -831,6 +831,7 @@ def build_media_notify_params(notify_action=None, session=None, timeline=None, m
         'title': notify_params['full_title'],
         'library_name': notify_params['library_name'],
         'show_name': show_name,
+        'show_name_slug': show_name.lower().replace(' ', '-').replace('(', '').replace(')', '').replace("'", '').replace('.', '-').rstrip('-'),
         'episode_name': episode_name,
         'artist_name': artist_name,
         'album_name': album_name,


### PR DESCRIPTION
Takes the name of the show and generates a slug for use in a URL suffix.

In this way the TV show can be directly linked in the email to the page on web service like Sonarr.