### PR TITLE
Refactor OAuth Login

### DIFF
--- a/plexpy/plextv.py
+++ b/plexpy/plextv.py
@@ -221,7 +221,8 @@ class PlexTV(object):
             return None
 
         for a in xml_head:
-            if helpers.get_xml_attr(a, 'clientIdentifier') == plexpy.CONFIG.PMS_IDENTIFIER:
+            if helpers.get_xml_attr(a, 'clientIdentifier') == plexpy.CONFIG.PMS_IDENTIFIER \
+                    and 'server' in helpers.get_xml_attr(a, 'provides'):
                 server_token = helpers.get_xml_attr(a, 'accessToken')
                 break
 

--- a/plexpy/plextv.py
+++ b/plexpy/plextv.py
@@ -211,17 +211,17 @@ class PlexTV(object):
 
 
     def get_server_token(self):
-        servers = self.get_plextv_server_list(output_format='xml')
+        servers = self.get_plextv_resources(output_format='xml')
         server_token = ''
 
         try:
-            xml_head = servers.getElementsByTagName('Server')
+            xml_head = servers.getElementsByTagName('Device')
         except Exception as e:
             logger.warn(u"Tautulli PlexTV :: Unable to parse XML for get_server_token: %s." % e)
             return None
 
         for a in xml_head:
-            if helpers.get_xml_attr(a, 'machineIdentifier') == plexpy.CONFIG.PMS_IDENTIFIER:
+            if helpers.get_xml_attr(a, 'clientIdentifier') == plexpy.CONFIG.PMS_IDENTIFIER:
                 server_token = helpers.get_xml_attr(a, 'accessToken')
                 break
 
@@ -812,7 +812,7 @@ class PlexTV(object):
 
         # Get proper download
         releases = platform_downloads.get('releases', [{}])
-        release = next((r for r in releases if r['distro'] == plexpy.CONFIG.PMS_UPDATE_DISTRO and 
+        release = next((r for r in releases if r['distro'] == plexpy.CONFIG.PMS_UPDATE_DISTRO and
                         r['build'] == plexpy.CONFIG.PMS_UPDATE_DISTRO_BUILD), releases[0])
 
         download_info = {'update_available': v_new > v_old,


### PR DESCRIPTION
I was able to refactor the OAuth login to work by using `get_plextv_resources()` vs `get_plextv_server_list()`. I think this is a better method of determining the client accessToken in general since it follows the same method as the plex web app/players. With these changes OAuth should work with or without remote access just like it does for the plex web app and devices. 
