### PR TITLE
Move refresh image button to right div for track results

### DIFF
--- a/data/interfaces/default/info_search_results_list.html
+++ b/data/interfaces/default/info_search_results_list.html
@@ -190,12 +190,12 @@ DOCUMENTATION :: END
         <li>
             <a href="info?rating_key=${child['rating_key']}" id="${child['rating_key']}">
                 <div class="item-children-poster">
-                    <div class="item-children-poster-face cover-item style="background-image: url(pms_image_proxy?img=${child['thumb']}&width=300&height=300&fallback=cover);"></div>
+                    <div class="item-children-poster-face cover-item" style="background-image: url(pms_image_proxy?img=${child['thumb']}&width=300&height=300&fallback=cover);"></div>
                     % if _session['user_group'] == 'admin':
                     <span class="overlay-refresh-image" title="Refresh image"><i class="fa fa-refresh refresh_pms_image"></i></span>
                     % endif
                 </div>
-                <div class="item-children-instance-text-wrapper album-item">
+                <div class="item-children-instance-text-wrapper cover-item">
                     <h3 title="${child['title']}">${child['title']}</h3>
                 </div>
             </a>
@@ -219,7 +219,7 @@ DOCUMENTATION :: END
                     <span class="overlay-refresh-image" title="Refresh image"><i class="fa fa-refresh refresh_pms_image"></i></span>
                     % endif
                 </div>
-                <div class="item-children-instance-text-wrapper album-item">
+                <div class="item-children-instance-text-wrapper cover-item">
                     <h3 title="${child['parent_title']}">${child['parent_title']}</h3>
                     <h3 title="${child['title']}">${child['title']}</h3>
                 </div>
@@ -250,7 +250,7 @@ DOCUMENTATION :: END
                     <span class="overlay-refresh-image" title="Refresh image"><i class="fa fa-refresh refresh_pms_image"></i></span>
                     % endif
                 </div>
-                <div class="item-children-instance-text-wrapper album-item">
+                <div class="item-children-instance-text-wrapper cover-item">
                     <h3 title="${child['original_title'] or child['grandparent_title']}">${child['original_title'] or child['grandparent_title']}</h3>
                     <h3 title="${child['title']}">${child['title']}</h3>
                     <h3 title="${child['parent_title']}" class="text-muted">${child['parent_title']}</h3>

--- a/data/interfaces/default/info_search_results_list.html
+++ b/data/interfaces/default/info_search_results_list.html
@@ -246,10 +246,10 @@ DOCUMENTATION :: END
                             </div>
                         </div>
                     </div>
+                    % if _session['user_group'] == 'admin':
+                    <span class="overlay-refresh-image" title="Refresh image"><i class="fa fa-refresh refresh_pms_image"></i></span>
+                    % endif
                 </div>
-                % if _session['user_group'] == 'admin':
-                <span class="overlay-refresh-image" title="Refresh image"><i class="fa fa-refresh refresh_pms_image"></i></span>
-                % endif
                 <div class="item-children-instance-text-wrapper album-item">
                     <h3 title="${child['original_title'] or child['grandparent_title']}">${child['original_title'] or child['grandparent_title']}</h3>
                     <h3 title="${child['title']}">${child['title']}</h3>


### PR DESCRIPTION
It looked like this previously:

![chrome_2018-09-12_15-42-01](https://user-images.githubusercontent.com/5239767/45429303-54986c80-b6a3-11e8-91ce-bfb1ea2aa8ae.png)

With this pull request the issue should be fixed:

![chrome_2018-09-12_15-42-10](https://user-images.githubusercontent.com/5239767/45429368-77c31c00-b6a3-11e8-966a-c9ef052bcf4a.png)
