### PR TITLE
Fixed typo

### DIFF
--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -51,7 +51,7 @@ ExecStart=/opt/Tautulli/Tautulli.py --config /opt/Tautulli/config.ini --datadir 
 GuessMainPID=no
 Type=forking
 User=tautulli
-Group=tautlli
+Group=tautulli
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There was a typo on the group name in the systemd unit file. This was keeping tautulli from starting up correctly.