### PR TITLE
1 improvement & 1 bug fix regarding view offset in activity handler files

### DIFF
--- a/plexpy/activity_handler.py
+++ b/plexpy/activity_handler.py
@@ -228,6 +228,7 @@ class ActivityHandler(object):
             this_state = self.timeline['state']
             this_rating_key = str(self.timeline['ratingKey'])
             this_key = self.timeline['key']
+            this_view_offset = self.timeline['viewOffset']
 
             # Get the live tv session uuid
             this_live_uuid = this_key.split('/')[-1] if this_key.startswith('/livetv/sessions') else None
@@ -241,6 +242,7 @@ class ActivityHandler(object):
                 last_state = db_session['state']
                 last_rating_key = str(db_session['rating_key'])
                 last_live_uuid = db_session['live_uuid']
+                last_view_offset = db_session['view_offset']
 
                 # Make sure the same item is being played
                 if this_rating_key == last_rating_key or this_live_uuid == last_live_uuid:
@@ -250,6 +252,10 @@ class ActivityHandler(object):
                         # if the last set temporary stopped time exceeds 15 seconds
                         if int(time.time()) - db_session['stopped'] > 60:
                             self.update_db_session()
+
+                    # Update db session when view offset changes
+                    if this_view_offset != last_view_offset:
+                        self.update_db_session()
 
                     # Start our state checks
                     if this_state != last_state:

--- a/plexpy/activity_handler.py
+++ b/plexpy/activity_handler.py
@@ -228,7 +228,6 @@ class ActivityHandler(object):
             this_state = self.timeline['state']
             this_rating_key = str(self.timeline['ratingKey'])
             this_key = self.timeline['key']
-            this_view_offset = self.timeline['viewOffset']
 
             # Get the live tv session uuid
             this_live_uuid = this_key.split('/')[-1] if this_key.startswith('/livetv/sessions') else None
@@ -242,7 +241,6 @@ class ActivityHandler(object):
                 last_state = db_session['state']
                 last_rating_key = str(db_session['rating_key'])
                 last_live_uuid = db_session['live_uuid']
-                last_view_offset = db_session['view_offset']
 
                 # Make sure the same item is being played
                 if this_rating_key == last_rating_key or this_live_uuid == last_live_uuid:
@@ -252,10 +250,6 @@ class ActivityHandler(object):
                         # if the last set temporary stopped time exceeds 15 seconds
                         if int(time.time()) - db_session['stopped'] > 60:
                             self.update_db_session()
-
-                    # Update db session when view offset changes
-                    if this_view_offset != last_view_offset:
-                        self.update_db_session()
 
                     # Start our state checks
                     if this_state != last_state:

--- a/plexpy/activity_processor.py
+++ b/plexpy/activity_processor.py
@@ -156,10 +156,11 @@ class ActivityProcessor(object):
             # Reload json from raw stream info
             if session.get('raw_stream_info'):
                 raw_stream_info = json.loads(session['raw_stream_info'])
-                # Don't overwrite id, session_key, stopped
+                # Don't overwrite id, session_key, stopped, view_offset
                 raw_stream_info.pop('id', None)
                 raw_stream_info.pop('session_key', None)
                 raw_stream_info.pop('stopped', None)
+                raw_stream_info.pop('view_offset', None)
                 session.update(raw_stream_info)
 
             session = defaultdict(str, session)


### PR DESCRIPTION
1. This change in activity_handler.py results in a more up-to-date watch percentage for the currently playing items on the history page. This is done by updating the view offset field whenever it was changed in the session state notification object.

2. It happened to me several times that short songs showed up with a watch percentage of 0%. This is because the "view_offset" field in the "raw_stream_info" json was not always as up-to-date as the one in the session object. By excluding "view_offset" from being overwritten, the correct value will be written to "session_history."

Example of what I am talking about:
Before the fix:
![chrome_2018-09-21_02-42-33](https://user-images.githubusercontent.com/5239767/45853872-11e02f80-bd48-11e8-90dd-287ebe844c6c.png)
After the fix:
![chrome_2018-09-21_02-42-52](https://user-images.githubusercontent.com/5239767/45853876-14428980-bd48-11e8-8d40-32f6f2b303ef.png)