### PR TITLE
Adds ability to change notification/check interval for new plex server version

### DIFF
--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -825,15 +825,6 @@
                                 <p class="help-block">
                                     The interval (in hours) Tautulli will check for a new Plex Media Server update. Minimum 1, default 24.
                                 </p>
-                                    <div class="col-md-2">
-                                        <label for="pms_update_notify_interval">Notify Interval</label>
-                                        <input type="text" class="form-control" data-parsley-type="integer" id="pms_update_notify_interval" name="pms_update_notify_interval" value="${config['pms_update_notify_interval']}" size="3" data-parsley-range="[1,999]" data-parsley-trigger="change" data-parsley-errors-container="#pms_update_notify_interval_error" required>
-                                    </div>
-                                    <div id="pms_update_notify_interval_error" class="alert alert-danger settings-alert" role="alert"></div>
-                                </div>
-                                <p class="help-block">
-                                    The interval (in hours) Tautulli will notify about a new Plex Media Server version. Minimum 1, maximum 999, default 24.
-                                </p>
                             </div>
                         </div>
                         <div class="checkbox">

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -813,7 +813,18 @@
                                         <input type="hidden" class="form-control" id="pms_update_distro" name="pms_update_distro">
                                     </div>
                                 </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="pms_update_check_interval">Update Check Interval</label>
                                 <div class="row">
+                                    <div class="col-md-2">
+                                        <input type="text" class="form-control" data-parsley-type="integer" id="pms_update_check_interval" name="pms_update_check_interval" value="${config['pms_update_check_interval']}" size="3" data-parsley-min="1" data-parsley-trigger="change" data-parsley-errors-container="#pms_update_check_interval_error" required>
+                                    </div>
+                                    <div id="pms_update_check_interval_error" class="alert alert-danger settings-alert" role="alert"></div>
+                                </div>
+                                <p class="help-block">
+                                    The interval (in hours) Tautulli will check for a new Plex Media Server update. Minimum 1, default 24.
+                                </p>
                                     <div class="col-md-2">
                                         <label for="pms_update_notify_interval">Notify Interval</label>
                                         <input type="text" class="form-control" data-parsley-type="integer" id="pms_update_notify_interval" name="pms_update_notify_interval" value="${config['pms_update_notify_interval']}" size="3" data-parsley-range="[1,999]" data-parsley-trigger="change" data-parsley-errors-container="#pms_update_notify_interval_error" required>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -813,6 +813,16 @@
                                         <input type="hidden" class="form-control" id="pms_update_distro" name="pms_update_distro">
                                     </div>
                                 </div>
+                                <div class="row">
+                                    <div class="col-md-2">
+                                        <label for="pms_update_notify_interval">Notify Interval</label>
+                                        <input type="text" class="form-control" data-parsley-type="integer" id="pms_update_notify_interval" name="pms_update_notify_interval" value="${config['pms_update_notify_interval']}" size="3" data-parsley-range="[1,999]" data-parsley-trigger="change" data-parsley-errors-container="#pms_update_notify_interval_error" required>
+                                    </div>
+                                    <div id="pms_update_notify_interval_error" class="alert alert-danger settings-alert" role="alert"></div>
+                                </div>
+                                <p class="help-block">
+                                    The interval (in hours) Tautulli will notify about a new Plex Media Server version. Minimum 1, maximum 999, default 24.
+                                </p>
                             </div>
                         </div>
                         <div class="checkbox">

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -429,6 +429,7 @@ def initialize_scheduler():
 
         # Update check
         github_minutes = CONFIG.CHECK_GITHUB_INTERVAL if CONFIG.CHECK_GITHUB_INTERVAL and CONFIG.CHECK_GITHUB else 0
+        pms_update_notify_hours = CONFIG.PMS_UPDATE_NOTIFY_INTERVAL if 1 <= CONFIG.PMS_UPDATE_NOTIFY_INTERVAL <= 999 else 24
 
         schedule_job(versioncheck.check_update, 'Check GitHub for updates',
                      hours=0, minutes=github_minutes, seconds=0, args=(bool(CONFIG.PLEXPY_AUTO_UPDATE), True))
@@ -447,7 +448,7 @@ def initialize_scheduler():
             schedule_job(activity_pinger.check_server_access, 'Check for Plex remote access',
                          hours=0, minutes=0, seconds=60 * bool(CONFIG.MONITOR_REMOTE_ACCESS))
             schedule_job(activity_pinger.check_server_updates, 'Check for Plex updates',
-                         hours=12 * bool(CONFIG.MONITOR_PMS_UPDATES), minutes=0, seconds=0)
+                         hours=pms_update_notify_hours * bool(CONFIG.MONITOR_PMS_UPDATES), minutes=0, seconds=0)
 
             # Refresh the users list and libraries list
             user_hours = CONFIG.REFRESH_USERS_INTERVAL if 1 <= CONFIG.REFRESH_USERS_INTERVAL <= 24 else 12

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -429,7 +429,7 @@ def initialize_scheduler():
 
         # Update check
         github_minutes = CONFIG.CHECK_GITHUB_INTERVAL if CONFIG.CHECK_GITHUB_INTERVAL and CONFIG.CHECK_GITHUB else 0
-        pms_update_notify_hours = CONFIG.PMS_UPDATE_NOTIFY_INTERVAL if 1 <= CONFIG.PMS_UPDATE_NOTIFY_INTERVAL <= 999 else 24
+        pms_update_check_hours = CONFIG.PMS_UPDATE_CHECK_INTERVAL if 1 <= CONFIG.PMS_UPDATE_CHECK_INTERVAL else 24
 
         schedule_job(versioncheck.check_update, 'Check GitHub for updates',
                      hours=0, minutes=github_minutes, seconds=0, args=(bool(CONFIG.PLEXPY_AUTO_UPDATE), True))

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -448,7 +448,7 @@ def initialize_scheduler():
             schedule_job(activity_pinger.check_server_access, 'Check for Plex remote access',
                          hours=0, minutes=0, seconds=60 * bool(CONFIG.MONITOR_REMOTE_ACCESS))
             schedule_job(activity_pinger.check_server_updates, 'Check for Plex updates',
-                         hours=pms_update_notify_hours * bool(CONFIG.MONITOR_PMS_UPDATES), minutes=0, seconds=0)
+                         hours=pms_update_check_hours * bool(CONFIG.MONITOR_PMS_UPDATES), minutes=0, seconds=0)
 
             # Refresh the users list and libraries list
             user_hours = CONFIG.REFRESH_USERS_INTERVAL if 1 <= CONFIG.REFRESH_USERS_INTERVAL <= 24 else 12

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -66,7 +66,7 @@ _CONFIG_DEFINITIONS = {
     'PMS_UPDATE_DISTRO': (str, 'PMS', ''),
     'PMS_UPDATE_DISTRO_BUILD': (str, 'PMS', ''),
     'PMS_WEB_URL': (str, 'PMS', 'https://app.plex.tv/desktop'),
-    'PMS_UPDATE_NOTIFY_INTERVAL': (int, 'Advanced', 24),
+    'PMS_UPDATE_CHECK_INTERVAL': (int, 'Advanced', 24),
     'TIME_FORMAT': (str, 'General', 'HH:mm'),
     'ANON_REDIRECT': (str, 'General', 'http://www.nullrefer.com/?'),
     'API_ENABLED': (int, 'General', 1),

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -66,6 +66,7 @@ _CONFIG_DEFINITIONS = {
     'PMS_UPDATE_DISTRO': (str, 'PMS', ''),
     'PMS_UPDATE_DISTRO_BUILD': (str, 'PMS', ''),
     'PMS_WEB_URL': (str, 'PMS', 'https://app.plex.tv/desktop'),
+    'PMS_UPDATE_NOTIFY_INTERVAL': (int, 'Advanced', 24),
     'TIME_FORMAT': (str, 'General', 'HH:mm'),
     'ANON_REDIRECT': (str, 'General', 'http://www.nullrefer.com/?'),
     'API_ENABLED': (int, 'General', 1),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -2755,7 +2755,7 @@ class WebInterface(object):
             "pms_uuid": plexpy.CONFIG.PMS_UUID,
             "pms_web_url": plexpy.CONFIG.PMS_WEB_URL,
             "pms_name": plexpy.CONFIG.PMS_NAME,
-            "pms_update_notify_interval": plexpy.CONFIG.PMS_UPDATE_NOTIFY_INTERVAL,
+            "pms_update_check_interval": plexpy.CONFIG.PMS_UPDATE_CHECK_INTERVAL,
             "date_format": plexpy.CONFIG.DATE_FORMAT,
             "time_format": plexpy.CONFIG.TIME_FORMAT,
             "week_start_monday": checked(plexpy.CONFIG.WEEK_START_MONDAY),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -2878,7 +2878,7 @@ class WebInterface(object):
         if kwargs.get('check_github') != plexpy.CONFIG.CHECK_GITHUB or \
             kwargs.get('refresh_libraries_interval') != str(plexpy.CONFIG.REFRESH_LIBRARIES_INTERVAL) or \
             kwargs.get('refresh_users_interval') != str(plexpy.CONFIG.REFRESH_USERS_INTERVAL) or \
-            kwargs.get('pms_update_notify_interval') != str(plexpy.CONFIG.PMS_UPDATE_NOTIFY_INTERVAL) or \
+            kwargs.get('pms_update_check_interval') != str(plexpy.CONFIG.PMS_UPDATE_CHECK_INTERVAL) or \
             kwargs.get('monitor_pms_updates') != plexpy.CONFIG.MONITOR_PMS_UPDATES or \
             kwargs.get('monitor_remote_access') != plexpy.CONFIG.MONITOR_REMOTE_ACCESS or \
             kwargs.get('pms_url_manual') != plexpy.CONFIG.PMS_URL_MANUAL:

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -2755,6 +2755,7 @@ class WebInterface(object):
             "pms_uuid": plexpy.CONFIG.PMS_UUID,
             "pms_web_url": plexpy.CONFIG.PMS_WEB_URL,
             "pms_name": plexpy.CONFIG.PMS_NAME,
+            "pms_update_notify_interval": plexpy.CONFIG.PMS_UPDATE_NOTIFY_INTERVAL,
             "date_format": plexpy.CONFIG.DATE_FORMAT,
             "time_format": plexpy.CONFIG.TIME_FORMAT,
             "week_start_monday": checked(plexpy.CONFIG.WEEK_START_MONDAY),
@@ -2877,6 +2878,7 @@ class WebInterface(object):
         if kwargs.get('check_github') != plexpy.CONFIG.CHECK_GITHUB or \
             kwargs.get('refresh_libraries_interval') != str(plexpy.CONFIG.REFRESH_LIBRARIES_INTERVAL) or \
             kwargs.get('refresh_users_interval') != str(plexpy.CONFIG.REFRESH_USERS_INTERVAL) or \
+            kwargs.get('pms_update_notify_interval') != str(plexpy.CONFIG.PMS_UPDATE_NOTIFY_INTERVAL) or \
             kwargs.get('monitor_pms_updates') != plexpy.CONFIG.MONITOR_PMS_UPDATES or \
             kwargs.get('monitor_remote_access') != plexpy.CONFIG.MONITOR_REMOTE_ACCESS or \
             kwargs.get('pms_url_manual') != plexpy.CONFIG.PMS_URL_MANUAL:


### PR DESCRIPTION
Add config variable PMS_UPDATE_NOTIFY_INTERVAL and settings interface to be able to change how often we notify about/check for a new plex version