### PR TITLE
Systemd restart policy note

### DIFF
--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -41,9 +41,6 @@
 #    - WantedBy= specifies which target (i.e. runlevel) to start Tautulli for.
 #       multi-user.target equates to runlevel 3 (multi-user text mode)
 #       graphical.target  equates to runlevel 5 (multi-user X11 graphical mode)
-#
-#    - Uncomment the two lines Restart= and RestartSec= below to allow Tautulli
-#       to restart if it crashes.
 
 [Unit]
 Description=Tautulli - Stats for Plex Media Server usage
@@ -56,8 +53,8 @@ GuessMainPID=no
 Type=forking
 User=tautulli
 Group=tautulli
-# Restart=on-abnormal
-# RestartSec=5
+Restart=on-abnormal
+RestartSec=5
 StartLimitInterval=90
 StartLimitBurst=3
 

--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -44,8 +44,6 @@
 #
 #    - Uncomment the two lines Restart= and RestartSec= below to allow Tautulli
 #       to restart if it crashes.
-#       Warning! If your setup is broken and Tautulli crashes on startup, these
-#       lines will cause it to restart forever until you stop it!
 
 [Unit]
 Description=Tautulli - Stats for Plex Media Server usage
@@ -60,6 +58,8 @@ User=tautulli
 Group=tautulli
 # Restart=on-abnormal
 # RestartSec=5
+StartLimitInterval=90
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -41,6 +41,11 @@
 #    - WantedBy= specifies which target (i.e. runlevel) to start Tautulli for.
 #       multi-user.target equates to runlevel 3 (multi-user text mode)
 #       graphical.target  equates to runlevel 5 (multi-user X11 graphical mode)
+#
+#    - Uncomment the two lines Restart= and RestartSec= below to allow Tautulli
+#       to restart if it crashes.
+#       Warning! If your setup is broken and Tautulli crashes on startup, these
+#       lines will cause it to restart forever until you stop it!
 
 [Unit]
 Description=Tautulli - Stats for Plex Media Server usage
@@ -53,6 +58,8 @@ GuessMainPID=no
 Type=forking
 User=tautulli
 Group=tautulli
+# Restart=on-abnormal
+# RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If Tautulli ever crashes due to a failure of some sort the policies mentioned here will automatically restart it, with the caveat that they will _always_ restart it, even if it is going to crash right away again!

`on-abnormal` appears to be the best policy choice here from what [the documentation](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=) says.

Closes #1334.