### PR TITLE
Add gzip encoding as a configurable option

### DIFF
--- a/Tautulli.py
+++ b/Tautulli.py
@@ -240,6 +240,7 @@ def main():
         'http_root': plexpy.CONFIG.HTTP_ROOT,
         'http_environment': plexpy.CONFIG.HTTP_ENVIRONMENT,
         'http_proxy': plexpy.CONFIG.HTTP_PROXY,
+        'http_gzip': plexpy.CONFIG.HTTP_GZIP,
         'enable_https': plexpy.CONFIG.ENABLE_HTTPS,
         'https_cert': plexpy.CONFIG.HTTPS_CERT,
         'https_cert_chain': plexpy.CONFIG.HTTPS_CERT_CHAIN,

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -493,6 +493,12 @@
                             </label>
                             <p class="help-block">Respect the X-Forwarded-Proto header. Used for reverse proxies with SSL.</p>
                         </div>
+                       <div class="checkbox advanced-setting">
+                            <label>
+                                <input type="checkbox" class="http-settings" name="http_gzip" id="http_gzip" value="1" ${config['http_gzip']}> Enable Gzip Encoding
+                            </label>
+                            <p class="help-block">Enable Gzip encoding in web responses. Disabling this can help with an IIS reverse proxy.</p>
+                        </div>
                         <div class="checkbox advanced-setting">
                             <label>
                                 <input type="checkbox" class="http-settings" name="enable_https" id="enable_https" value="1" ${config['enable_https']} /> Enable HTTPS

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -220,6 +220,7 @@ _CONFIG_DEFINITIONS = {
     'HTTP_PASSWORD': (str, 'General', ''),
     'HTTP_PORT': (int, 'General', 8181),
     'HTTP_PROXY': (int, 'General', 0),
+    'HTTP_GZIP': (int, 'General', 1),
     'HTTP_ROOT': (str, 'General', ''),
     'HTTP_USERNAME': (str, 'General', ''),
     'HTTP_PLEX_ADMIN': (int, 'General', 0),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -2729,6 +2729,7 @@ class WebInterface(object):
             "http_password": http_password,
             "http_root": plexpy.CONFIG.HTTP_ROOT,
             "http_proxy": checked(plexpy.CONFIG.HTTP_PROXY),
+            "http_gzip": checked(plexpy.CONFIG.HTTP_GZIP),
             "http_plex_admin": checked(plexpy.CONFIG.HTTP_PLEX_ADMIN),
             "launch_browser": checked(plexpy.CONFIG.LAUNCH_BROWSER),
             "enable_https": checked(plexpy.CONFIG.ENABLE_HTTPS),
@@ -2837,7 +2838,7 @@ class WebInterface(object):
             "notify_consecutive", "notify_recently_added_upgrade",
             "notify_group_recently_added_grandparent", "notify_group_recently_added_parent",
             "monitor_pms_updates", "monitor_remote_access", "get_file_sizes", "log_blacklist", "http_hash_password",
-            "allow_guest_access", "cache_images", "http_proxy", "http_basic_auth", "notify_concurrent_by_ip",
+            "allow_guest_access", "cache_images", "http_proxy", "http_gzip", "http_basic_auth", "notify_concurrent_by_ip",
             "history_table_activity", "plexpy_auto_update",
             "themoviedb_lookup", "tvmaze_lookup", "http_plex_admin",
             "newsletter_self_hosted", "newsletter_inline_styles", "win_sys_tray"

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -99,7 +99,7 @@ def initialize(options):
         '/': {
             'tools.staticdir.root': os.path.join(plexpy.PROG_DIR, 'data'),
             'tools.proxy.on': bool(options['http_proxy']),
-            'tools.gzip.on': True,
+            'tools.gzip.on': bool(options['http_gzip']),
             'tools.gzip.mime_types': ['text/html', 'text/plain', 'text/css',
                                       'text/javascript', 'application/json',
                                       'application/javascript'],


### PR DESCRIPTION
If you reverse proxy Tautulli through IIS, you have to do funky stuff with the encoding to make it work. This just adds an option to disable it inside the app to fix the problem.

I'm only _mostly_ sure I added this config option correctly. Let me know if I did something dumb.