### PR TITLE
Update init.systemd

### DIFF
--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -24,9 +24,11 @@
 #    - The example settings in this file assume that Tautulli is installed to: /opt/Tautulli
 #
 #    - To create this user and give it ownership of the Tautulli directory:
-#       Ubuntu/Debian: sudo addgroup tautulli && sudo adduser --system --no-create-home tautulli --ingroup tautulli
-#       CentOS/Fedora: sudo adduser --system --no-create-home tautulli
-#       sudo chown tautulli:tautulli -R /opt/Tautulli
+#       1. Create the user:
+#           Ubuntu/Debian: sudo addgroup tautulli && sudo adduser --system --no-create-home tautulli --ingroup tautulli
+#           CentOS/Fedora: sudo adduser --system --no-create-home tautulli
+#       2. Give the user ownership of the Tautulli directory:
+#           sudo chown tautulli:tautulli -R /opt/Tautulli
 #
 #    - Adjust ExecStart= to point to:
 #       1. Your Tautulli executable


### PR DESCRIPTION
Edited user creation and directory ownership instructions in the configuration notes for clarity. Current version may give novice users the impression that the ownership command is only executed on CentOS/Fedora.