### PR TITLE
Slightly reduce margin on stat cards

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -1159,7 +1159,7 @@ a .dashboard-activity-metadata-user-thumb:hover {
     height: 160px;
     min-width: 350px;
     max-width: 500px;
-    margin-right: 25px;
+    margin-right: 15px;
     margin-bottom: 25px;
 }
 .dashboard-stats-container {


### PR DESCRIPTION
I've got a single vertical 1080p monitor and currently all the cards are in a single line, but reducing the margins on cards slightly allows them to appear in dual lines.

https://i.imgur.com/FyNBVtv.png Is how it currently looks.