### PR TITLE
Change humanFileSize to default to SI notation

### DIFF
--- a/plexpy/helpers.py
+++ b/plexpy/helpers.py
@@ -1006,7 +1006,7 @@ def build_datatables_json(kwargs, dt_columns, default_sort_col=None):
     return json.dumps(json_data)
 
 
-def humanFileSize(bytes, si=False):
+def humanFileSize(bytes, si=True):
     if str(bytes).isdigit():
         bytes = int(bytes)
     else:


### PR DESCRIPTION
The current code creates output like “12.0 GiB” instead of much more readable “12 GB”. This change modifies the default behavior of humanFileSize() to do just that.