### PR TITLE
Add crossorigin use-credentials attribute to manifest tag

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -28,7 +28,7 @@
 
     <!-- ICONS -->
     <!-- Android -->
-    <link rel="manifest" href="${http_root}images/favicon/manifest.json?v=2.0.5">
+    <link rel="manifest" href="${http_root}images/favicon/manifest.json?v=2.0.5" crossorigin="use-credentials">
     <meta name="theme-color" content="#282a2d">
     <!-- Apple -->
     <link rel="apple-touch-icon" sizes="180x180" href="${http_root}images/favicon/apple-touch-icon.png?v=2.0.5">

--- a/data/interfaces/default/login.html
+++ b/data/interfaces/default/login.html
@@ -24,7 +24,7 @@
 
     <!-- ICONS -->
     <!-- Android -->
-    <link rel="manifest" href="${http_root}images/favicon/manifest.json?v=2.0.5">
+    <link rel="manifest" href="${http_root}images/favicon/manifest.json?v=2.0.5" crossorigin="use-credentials>
     <meta name="theme-color" content="#282a2d">
     <!-- Apple -->
     <link rel="apple-touch-icon" sizes="180x180" href="${http_root}images/favicon/apple-touch-icon.png?v=2.0.5">

--- a/data/interfaces/default/welcome.html
+++ b/data/interfaces/default/welcome.html
@@ -27,7 +27,7 @@
 
     <!-- ICONS -->
     <!-- Android -->
-    <link rel="manifest" href="${http_root}images/favicon/manifest.json?v=2.0.5">
+    <link rel="manifest" href="${http_root}images/favicon/manifest.json?v=2.0.5" crossorigin="use-credentials">
     <meta name="theme-color" content="#282a2d">
     <!-- Apple -->
     <link rel="apple-touch-icon" sizes="180x180" href="${http_root}images/favicon/apple-touch-icon.png?v=2.0.5">


### PR DESCRIPTION
When serving Tautulli behind an authentication proxy (ex. https://github.com/pusher/oauth2_proxy) the manifest request will fail because cookies are not sent with the manifest request.

See https://developer.mozilla.org/en-US/docs/Web/Manifest:
> Note: If the manifest requires credentials to fetch - the `crossorigin` attribute must be set to `"use-credentials"`, even if the manifest file is in the same origin as the current page.

This PR adds the necessary attribute so that cookies will be sent with manifest requests.