### PR TITLE
Fix display of IPv6 addresses in activity panes

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -973,7 +973,7 @@ a .users-poster-face:hover {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 140px;
+    max-width: 125px;
 }
 .dashboard-activity-info-time {
     position: absolute;
@@ -3102,6 +3102,7 @@ div.dataTables_info {
     border-left-color: #fff;
 }
 .tooltip-inner {
+    max-width: 250px;
     color: #000;
     background: #fff;
     border: 0;

--- a/data/interfaces/default/current_activity_instance.html
+++ b/data/interfaces/default/current_activity_instance.html
@@ -301,7 +301,11 @@ DOCUMENTATION :: END
                                     % endif
                                     <span id="location-${sk}">${data['location'].upper()}</span>:
                                     % if data['ip_address'] != 'N/A':
-                                    <span class="ip-container"><span class="ip-address">${data['ip_address']}</span></span>
+                                        % if len(data['ip_address']) > 20:
+                                        <span class="ip-container"><span class="ip-address" data-toggle="tooltip" title="${data['ip_address']}">${data['ip_address']}</span></span>
+                                        % else:
+                                        <span class="ip-container"><span class="ip-address">${data['ip_address']}</span></span>
+                                        % endif
                                         % if data['relayed']:
                                         <span data-toggle="tooltip" title="Plex Relay"><i class="fa fa-exclamation-circle"></i></span>
                                         % else:


### PR DESCRIPTION
* Fix wrong width of ip-address field, causing it to be displayed as "…", when exceeding 125px
* Add tooltip with full IP address on hover, if the address is longer than 20 characters (maximum length that can be shown in 125px)