### PR TITLE
Fix to support older versions of git

### DIFF
--- a/plexpy/versioncheck.py
+++ b/plexpy/versioncheck.py
@@ -251,7 +251,7 @@ def update():
         logger.info('Windows .exe updating not supported yet.')
 
     elif plexpy.INSTALL_TYPE == 'git':
-        output, err = runGit('pull {} {} --ff-only'.format(plexpy.CONFIG.GIT_REMOTE,
+        output, err = runGit('pull --ff-only {} {}'.format(plexpy.CONFIG.GIT_REMOTE,
                                                            plexpy.CONFIG.GIT_BRANCH))
 
         if not output:


### PR DESCRIPTION
Older versions of git (at least 2.1.x on Debian 8) do not support using the `--ff-only` parameter as the last positional parameter. Just need to move it up before remote/branch.

Without this the versioncheck.py silently breaks, and update is never performed
```
2020-04-04 11:30:09 - INFO    :: MainThread : Tautulli is updating...
2020-04-04 11:30:09 - DEBUG   :: MainThread : Trying to execute: "git pull origin master --ff-only" with shell in /opt/plexpy
2020-04-04 11:30:09 - DEBUG   :: MainThread : Git output: error: unknown option `ff-only'
usage: git fetch [<options>] [<repository> [<refspec>...]]
   or: git fetch [<options>] <group>
   or: git fetch --multiple [<options>] [(<repository> | <group>)...]
   or: git fetch --all [<options>]

    -v, --verbose         be more verbose
    -q, --quiet           be more quiet
    --all                 fetch from all remotes
    -a, --append          append to .git/FETCH_HEAD instead of overwriting
    --upload-pack <path>  path to upload pack on remote end
    -f, --force           force overwrite of local branch
    -m, --multiple        fetch from multiple remotes
    -t, --tags            fetch all tags and associated objects
    -n                    do not fetch all tags (--no-tags)
    -p, --prune           prune remote-tracking branches no longer on remote
    --recurse-submodules[=<on-demand>]
                          control recursive fetching of submodules
    --dry-run             dry run
    -k, --keep            keep downloaded pack
    -u, --update-head-ok  allow updating of HEAD ref
    --progress            force progress reporting
    --depth <depth>       deepen history of shallow clone
    --unshallow           convert to a complete repository
    --update-shallow      accept refs that update .git/shallow
    --refmap <refmap>     specify fetch refmap
```

Someone seemed to have mentioned the same in the commit notes here: https://github.com/Tautulli/Tautulli/commit/2a3bd3413f3ff17e8b50468cee638050763e4a10