### PR TITLE
Add newsletter month/year time frame option

### DIFF
--- a/data/interfaces/default/newsletter_config.html
+++ b/data/interfaces/default/newsletter_config.html
@@ -61,8 +61,10 @@
                                                     <span class="input-group-addon form-control btn-dark inactive">Last</span>
                                                     <input type="number" class="form-control" id="newsletter_config_time_frame" name="newsletter_config_time_frame" value="${newsletter['config']['time_frame']}">
                                                     <select class="form-control" id="newsletter_config_time_frame_units" name="newsletter_config_time_frame_units">
-                                                        <option value="days" ${'selected' if newsletter['config']['time_frame_units'] == 'days' else ''}>days</option>
                                                         <option value="hours" ${'selected' if newsletter['config']['time_frame_units'] == 'hours' else ''}>hours</option>
+                                                        <option value="days" ${'selected' if newsletter['config']['time_frame_units'] == 'days' else ''}>days</option>
+                                                        <option value="months" ${'selected' if newsletter['config']['time_frame_units'] == 'months' else ''}>months</option>
+                                                        <option value="years" ${'selected' if newsletter['config']['time_frame_units'] == 'years' else ''}>years</option>
                                                     </select>
                                                 </div>
                                             </div>

--- a/plexpy/newsletters.py
+++ b/plexpy/newsletters.py
@@ -386,6 +386,10 @@ class Newsletter(object):
         if self.start_date is None:
             if self.config['time_frame_units'] == 'days':
                 self.start_date = self.end_date.shift(days=-self.config['time_frame']+1).floor('day')
+            elif self.config['time_frame_units'] == 'months':
+                self.start_date = self.end_date.shift(months=-self.config['time_frame']).floor('day')
+            elif self.config['time_frame_units'] == 'years':
+                self.start_date = self.end_date.shift(years=-self.config['time_frame']).floor('day')
             else:
                 self.start_date = self.end_date.shift(hours=-self.config['time_frame']).floor('hour')
 

--- a/plexpy/newsletters.py
+++ b/plexpy/newsletters.py
@@ -387,9 +387,9 @@ class Newsletter(object):
             if self.config['time_frame_units'] == 'days':
                 self.start_date = self.end_date.shift(days=-self.config['time_frame']+1).floor('day')
             elif self.config['time_frame_units'] == 'months':
-                self.start_date = self.end_date.shift(months=-self.config['time_frame']).floor('day')
+                self.start_date = self.end_date.shift(months=-self.config['time_frame'], days=1).floor('day')
             elif self.config['time_frame_units'] == 'years':
-                self.start_date = self.end_date.shift(years=-self.config['time_frame']).floor('day')
+                self.start_date = self.end_date.shift(years=-self.config['time_frame'], days=1).floor('day')
             else:
                 self.start_date = self.end_date.shift(hours=-self.config['time_frame']).floor('hour')
 


### PR DESCRIPTION
Howdy!

I'd like to send my newsletter monthly. I noticed there's a scheduling option for "monthly" in the scheduler -- "time frame" however can only do "30 days", which will miss a day some months. Added "monthly" time frame option to match what's availability in scheduler, and added "yearly" as well for good measure, for folks who may want to do yearly. Yeh neh?

Also: Moved "hourly" to the top to keep list chron; not sure what you think about the menu ordering?

Cheers 🙌