### PR TITLE
Allow custom time_queries for get_watch_stats

### DIFF
--- a/API.md
+++ b/API.md
@@ -1066,6 +1066,7 @@ Required parameters:
 
 Optional parameters:
     grouping (int):         0 or 1
+    time_queries (str):     "1, 7, 30, 0"
 
 Returns:
     json:
@@ -2378,6 +2379,7 @@ Required parameters:
 
 Optional parameters:
     grouping (int):         0 or 1
+    time_queries (str):     "1, 7, 30, 0"
 
 Returns:
     json:

--- a/plexpy/libraries.py
+++ b/plexpy/libraries.py
@@ -812,16 +812,20 @@ class Libraries(object):
                 # If there is no library data we must return something
                 return default_return
 
-    def get_watch_time_stats(self, section_id=None, grouping=None):
+    def get_watch_time_stats(self, section_id=None, grouping=None, time_queries=None):
         if not session.allow_session_library(section_id):
             return []
 
         if grouping is None:
             grouping = plexpy.CONFIG.GROUP_HISTORY_TABLES
 
+        if time_queries is not None:
+            time_queries = map(int, time_queries.split(","))
+        else:
+            time_queries = [1, 7, 30, 0]
+
         monitor_db = database.MonitorDatabase()
 
-        time_queries = [1, 7, 30, 0]
         library_watch_time_stats = []
 
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'

--- a/plexpy/users.py
+++ b/plexpy/users.py
@@ -434,16 +434,20 @@ class Users(object):
                 # Use "Local" user to retain compatibility with PlexWatch database value
                 return default_return
 
-    def get_watch_time_stats(self, user_id=None, grouping=None):
+    def get_watch_time_stats(self, user_id=None, grouping=None, time_queries=None):
         if not session.allow_session_user(user_id):
             return []
 
         if grouping is None:
             grouping = plexpy.CONFIG.GROUP_HISTORY_TABLES
 
+        if time_queries is not None:
+            time_queries = map(int, time_queries.split(","))
+        else:
+            time_queries = [1, 7, 30, 0]
+
         monitor_db = database.MonitorDatabase()
 
-        time_queries = [1, 7, 30, 0]
         user_watch_time_stats = []
 
         group_by = 'reference_id' if grouping else 'id'

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -810,7 +810,7 @@ class WebInterface(object):
     @cherrypy.tools.json_out()
     @requireAuth(member_of("admin"))
     @addtoapi()
-    def get_library_watch_time_stats(self, section_id=None, grouping=None, **kwargs):
+    def get_library_watch_time_stats(self, section_id=None, grouping=None, time_queries=None, **kwargs):
         """ Get a library's watch time statistics.
 
             ```
@@ -819,6 +819,7 @@ class WebInterface(object):
 
             Optional parameters:
                 grouping (int):         0 or 1
+                time_queries (str):     "1, 7, 30, 0"
 
             Returns:
                 json:
@@ -845,7 +846,8 @@ class WebInterface(object):
 
         if section_id:
             library_data = libraries.Libraries()
-            result = library_data.get_watch_time_stats(section_id=section_id, grouping=grouping)
+            result = library_data.get_watch_time_stats(section_id=section_id, grouping=grouping,
+                                                       time_queries=time_queries)
             if result:
                 return result
             else:
@@ -1427,7 +1429,7 @@ class WebInterface(object):
     @cherrypy.tools.json_out()
     @requireAuth(member_of("admin"))
     @addtoapi()
-    def get_user_watch_time_stats(self, user_id=None, grouping=None, **kwargs):
+    def get_user_watch_time_stats(self, user_id=None, grouping=None, time_queries=None, **kwargs):
         """ Get a user's watch time statistics.
 
             ```
@@ -1436,6 +1438,7 @@ class WebInterface(object):
 
             Optional parameters:
                 grouping (int):         0 or 1
+                time_queries (str):     "1, 7, 30, 0"
 
             Returns:
                 json:
@@ -1462,7 +1465,7 @@ class WebInterface(object):
 
         if user_id:
             user_data = users.Users()
-            result = user_data.get_watch_time_stats(user_id=user_id, grouping=grouping)
+            result = user_data.get_watch_time_stats(user_id=user_id, grouping=grouping, time_queries=time_queries)
             if result:
                 return result
             else:


### PR DESCRIPTION
This is applying all the comments in the original PR of this idea at #1345. Since it seems abandoned by idlegravity.
In short, edited get_watch_time_stats of libraries and users to accept a custom time_queries parameter and return those.