### PR TITLE
Specify a full path to python

### DIFF
--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -50,7 +50,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=python /opt/Tautulli/Tautulli.py --config /opt/Tautulli/config.ini --datadir /opt/Tautulli --quiet --daemon --nolaunch
+ExecStart=/bin/python /opt/Tautulli/Tautulli.py --config /opt/Tautulli/config.ini --datadir /opt/Tautulli --quiet --daemon --nolaunch
 GuessMainPID=no
 Type=forking
 User=tautulli


### PR DESCRIPTION
Apparently some systemd implementations (all?) **require** a full path, so change `python` to `/bin/python` which should be viable on most systems.