### PR TITLE
Add first_seen to user IP Table

### DIFF
--- a/API.md
+++ b/API.md
@@ -2267,8 +2267,8 @@ Required parameters:
     user_id (str):                  The id of the Plex user
 
 Optional parameters:
-    order_column (str):             "last_seen", "ip_address", "platform", "player",
-                                    "last_played", "play_count"
+    order_column (str):             "last_seen", "first_seen", "ip_address", "platform",
+                                    "player", "last_played", "play_count"
     order_dir (str):                "desc" or "asc"
     start (int):                    Row to start from, 0
     length (int):                   Number of items to return, 25
@@ -2286,6 +2286,7 @@ Returns:
               "ip_address": "xxx.xxx.xxx.xxx",
               "last_played": "Game of Thrones - The Red Woman",
               "last_seen": 1462591869,
+              "first_seen": 1583968210,
               "live": 0,
               "media_index": 1,
               "media_type": "episode",

--- a/data/interfaces/default/js/tables/user_ips.js
+++ b/data/interfaces/default/js/tables/user_ips.js
@@ -1,3 +1,25 @@
+var date_format = 'YYYY-MM-DD';
+var time_format = 'hh:mm a';
+
+$.ajax({
+  url: 'get_date_formats',
+  type: 'GET',
+  success: function(data) {
+      date_format = data.date_format;
+      time_format = data.time_format;
+  }
+});
+
+var seenRender = function (data, type, full) {
+  return moment(data, "X").fromNow();
+};
+
+var seenCreatedCell = function (td, cellData, rowData, row, col) {
+  if (cellData !== null) {
+    $(td).attr('title', moment(cellData, "X").format(date_format + ' ' + time_format));
+  }
+};
+
 user_ip_table_options = {
     "destroy": true,
     "language": {
@@ -21,16 +43,24 @@ user_ip_table_options = {
     "columnDefs": [
         {
             "targets": [0],
-            "data":"last_seen",
-            "render": function ( data, type, full ) {
-                return moment(data, "X").fromNow();
-            },
+            "data": "last_seen",
+            "render": seenRender,
+            "createdCell": seenCreatedCell,
             "searchable": false,
             "width": "15%",
             "className": "no-wrap"
         },
         {
             "targets": [1],
+            "data": "first_seen",
+            "render": seenRender,
+            "createdCell": seenCreatedCell,
+            "searchable": false,
+            "width": "15%",
+            "className": "no-wrap"
+        },
+        {
+            "targets": [2],
             "data": "ip_address",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData) {
@@ -48,7 +78,7 @@ user_ip_table_options = {
             "className": "no-wrap modal-control-ip"
         },
         {
-            "targets": [2],
+            "targets": [3],
             "data": "platform",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -59,7 +89,7 @@ user_ip_table_options = {
             "className": "no-wrap"
         },
         {
-            "targets": [3],
+            "targets": [4],
             "data": "player",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -78,7 +108,7 @@ user_ip_table_options = {
             "className": "no-wrap modal-control"
         },
         {
-            "targets": [4],
+            "targets": [5],
             "data": "last_played",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== '') {
@@ -119,7 +149,7 @@ user_ip_table_options = {
             "className": "datatable-wrap"
         },
         {
-            "targets": [5],
+            "targets": [6],
             "data": "play_count",
             "searchable": false,
             "width": "10%",

--- a/data/interfaces/default/user.html
+++ b/data/interfaces/default/user.html
@@ -285,6 +285,7 @@ DOCUMENTATION :: END
                                             <thead>
                                                 <tr>
                                                     <th align="left" id="last_seen">Last Streamed</th>
+                                                    <th align="left" id="first_seen">First Streamed</th>
                                                     <th align="left" id="ip_address">IP Address</th>
                                                     <th align="left" id="platform">Last Platform</th>
                                                     <th align="left" id="player">Last Player</th>

--- a/plexpy/users.py
+++ b/plexpy/users.py
@@ -246,6 +246,7 @@ class Users(object):
 
         columns = ['session_history.id AS history_row_id',
                    'MAX(session_history.started) AS last_seen',
+                   'MIN(session_history.started) AS first_seen',
                    'session_history.ip_address',
                    'COUNT(session_history.id) AS play_count',
                    'session_history.platform',
@@ -306,6 +307,7 @@ class Users(object):
 
             row = {'history_row_id': item['history_row_id'],
                    'last_seen': item['last_seen'],
+                   'first_seen': item['first_seen'],
                    'ip_address': item['ip_address'],
                    'play_count': item['play_count'],
                    'platform': platform,

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1378,8 +1378,8 @@ class WebInterface(object):
                 user_id (str):                  The id of the Plex user
 
             Optional parameters:
-                order_column (str):             "last_seen", "ip_address", "platform", "player",
-                                                "last_played", "play_count"
+                order_column (str):             "last_seen", "first_seen", "ip_address", "platform",
+                                                "player", "last_played", "play_count"
                 order_dir (str):                "desc" or "asc"
                 start (int):                    Row to start from, 0
                 length (int):                   Number of items to return, 25
@@ -1397,6 +1397,7 @@ class WebInterface(object):
                           "ip_address": "xxx.xxx.xxx.xxx",
                           "last_played": "Game of Thrones - The Red Woman",
                           "last_seen": 1462591869,
+                          "first_seen": 1583968210,
                           "live": 0,
                           "media_index": 1,
                           "media_type": "episode",
@@ -1423,6 +1424,7 @@ class WebInterface(object):
         if not kwargs.get('json_data'):
             # TODO: Find some one way to automatically get the columns
             dt_columns = [("last_seen", True, False),
+                          ("first_seen", True, False),
                           ("ip_address", True, True),
                           ("platform", True, True),
                           ("player", True, True),


### PR DESCRIPTION
This PR adds a first_seen column to the user IP detail table, and also sets a title attr on both the first_seen and last_seen columns that shows the full date/time in the user's set formats.