### PR TITLE
Added "silent_message" option for Telegram Agent

### DIFF
--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -3365,7 +3365,7 @@ class TELEGRAM(Notifier):
     _DEFAULT_CONFIG = {'bot_token': '',
                        'chat_id': '',
                        'disable_web_preview': 0,
-                       'silent_message': 0,
+                       'silent_notification': 0,
                        'html_support': 1,
                        'incl_subject': 1,
                        'incl_poster': 0
@@ -3407,7 +3407,7 @@ class TELEGRAM(Notifier):
                     data.pop('disable_notification') #This prevents from alerting with 2 sounds Telegram when the Silent Message is OFF: one alert for the photo and the second one for the text
                 else:
                     data['caption'] = text.encode('utf-8')
-                    if self.config['silent_message']:
+                    if self.config['silent_notification']:
                         data['disable_notification'] = True
                     self.make_request('https://api.telegram.org/bot{}/sendPhoto'.format(self.config['bot_token']),
                                       data=data, files=files)
@@ -3418,7 +3418,7 @@ class TELEGRAM(Notifier):
         if self.config['disable_web_preview']:
             data['disable_web_page_preview'] = True
 
-        if self.config['silent_message']:
+        if self.config['silent_notification']:
             data['disable_notification'] = True
 
         headers = {'Content-type': 'application/x-www-form-urlencoded'}
@@ -3470,8 +3470,8 @@ class TELEGRAM(Notifier):
                           'input_type': 'checkbox'
                           },
                          {'label': 'Enable Silent Notifications',
-                          'value': self.config['silent_message'],
-                          'name': 'telegram_silent_message',
+                          'value': self.config['silent_notification'],
+                          'name': 'telegram_silent_notification',
                           'description': 'Send notifications silently without any alert sounds.',
                           'input_type': 'checkbox'
                           }

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 #  This file is part of Tautulli.
 #
@@ -3398,24 +3398,28 @@ class TELEGRAM(Notifier):
                 poster_filename = 'poster_{}.png'.format(pretty_metadata.parameters['rating_key'])
                 files = {'photo': (poster_filename, poster_content, 'image/png')}
 
-                if len(text) > 1024:
+                max_caption = len(text)
+
+                if max_caption > 1024:
                     data['disable_notification'] = True
+                    self.make_request('https://api.telegram.org/bot{}/sendPhoto'.format(self.config['bot_token']),
+                                      data=data, files=files)
+                    data.pop('disable_notification') #This prevents from alerting with 2 sounds Telegram when the Silent Message is OFF: one alert for the photo and the second one for the text
                 else:
                     data['caption'] = text.encode('utf-8')
-
-                r = self.make_request('https://api.telegram.org/bot{}/sendPhoto'.format(self.config['bot_token']),
+                    if self.config['silent_message']:
+                        data['disable_notification'] = True
+                    self.make_request('https://api.telegram.org/bot{}/sendPhoto'.format(self.config['bot_token']),
                                       data=data, files=files)
-
-                if not data.pop('disable_notification', None):
-                    return r
+                    return
 
         data['text'] = (text[:4093] + (text[4093:] and '...')).encode('utf-8')
 
-        if self.config['silent_message']:
-            data['disable_notification'] = True
-
         if self.config['disable_web_preview']:
             data['disable_web_page_preview'] = True
+
+        if self.config['silent_message']:
+            data['disable_notification'] = True
 
         headers = {'Content-type': 'application/x-www-form-urlencoded'}
 

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -3469,10 +3469,10 @@ class TELEGRAM(Notifier):
                           'description': 'Disables automatic link previews for links in the message',
                           'input_type': 'checkbox'
                           },
-                         {'label': 'Enable Silent Messages',
+                         {'label': 'Enable Silent Notifications',
                           'value': self.config['silent_message'],
                           'name': 'telegram_silent_message',
-                          'description': 'Sends the message silently. Users will receive a notification with no sound.',
+                          'description': 'Send notifications silently without any alert sounds.',
                           'input_type': 'checkbox'
                           }
                          ]

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 #  This file is part of Tautulli.
 #
@@ -3365,6 +3365,7 @@ class TELEGRAM(Notifier):
     _DEFAULT_CONFIG = {'bot_token': '',
                        'chat_id': '',
                        'disable_web_preview': 0,
+                       'silent_message': 0,
                        'html_support': 1,
                        'incl_subject': 1,
                        'incl_poster': 0
@@ -3409,6 +3410,9 @@ class TELEGRAM(Notifier):
                     return r
 
         data['text'] = (text[:4093] + (text[4093:] and '...')).encode('utf-8')
+
+        if self.config['silent_message']:
+            data['disable_notification'] = True
 
         if self.config['disable_web_preview']:
             data['disable_web_page_preview'] = True
@@ -3459,6 +3463,12 @@ class TELEGRAM(Notifier):
                           'value': self.config['disable_web_preview'],
                           'name': 'telegram_disable_web_preview',
                           'description': 'Disables automatic link previews for links in the message',
+                          'input_type': 'checkbox'
+                          },
+                         {'label': 'Enable Silent Messages',
+                          'value': self.config['silent_message'],
+                          'name': 'telegram_silent_message',
+                          'description': 'Sends the message silently. Users will receive a notification with no sound.',
                           'input_type': 'checkbox'
                           }
                          ]


### PR DESCRIPTION
I opened a feature request (https://feathub.com/Tautulli/Tautulli/+444) this morning, then I tried to implement this on my own and it works. So I added a new checkbox in the notification telegram config in order to send new messages silently. The telegram users will receive a notification with no sound. In this way I can use the bot to spam non-important messages in the group (like watched notifications, play notification etc) without alerting everytime anyone.