### PR TITLE
Add negative margin to sections with fixed cards

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -744,6 +744,11 @@ a .users-poster-face:hover {
 .users-name {
     position: relative;
 }
+#currentActivity,
+.home-platforms,
+.library-platforms {
+    margin-right: -25px;
+}
 #dashboard-checking-activity,
 #dashboard-no-activity {
     margin-bottom: 20px;


### PR DESCRIPTION
Cards have a 25px right margin, this sets a negative margin on those sections so that cards will sit within the bootstrap row without needing an extra 25px. I believe this is only applicable to the index view, but the might happen somewhere else that I missed.