### PR TITLE
Avoid daemon forking with systemd

### DIFF
--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -52,9 +52,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/python3 /opt/Tautulli/Tautulli.py --config /opt/Tautulli/config.ini --datadir /opt/Tautulli --quiet --daemon --nolaunch
-GuessMainPID=no
-Type=forking
+ExecStart=/usr/bin/python3 /opt/Tautulli/Tautulli.py --config /opt/Tautulli/config.ini --datadir /opt/Tautulli --quiet --nolaunch
 User=tautulli
 Group=tautulli
 Restart=on-abnormal


### PR DESCRIPTION
systemd units allow to run processes in foreground while daemonization is done on systemd service level when using Type=simple (default). This allows systemd to reliably track the service state, signals and could catch outputs, i.e. it is possible to remove "--quiet" to have Tautulli logging to systemd journal (journalctl) additionally or alternatively to log files.

In case of Type=forking, a PID file is required to allow system reliably determine the service state, which would be an alternative, but has no real advantage. The solution with "GuessMainPID=no" allows systemd to correctly determine the service active state, but e.g. when it is killed, it is seen as "Succeeded." since systemd cannot track the exit code or signal.
__________________
Probably this is all well known and there is some good reason for the current forking solution, but it is better to ask/discuss that based on an actual alternative suggestion 🙂.