### PR TITLE
Fix styling of Apple data-detectors in newsletters

### DIFF
--- a/data/interfaces/newsletters/recently_added.html
+++ b/data/interfaces/newsletters/recently_added.html
@@ -521,7 +521,7 @@
                 line-height: 100%;
             }
 
-            .apple-link a {
+            a[x-apple-data-detectors] {
                 color: inherit !important;
                 font-family: inherit !important;
                 font-size: inherit !important;

--- a/data/interfaces/newsletters/recently_added.internal.html
+++ b/data/interfaces/newsletters/recently_added.internal.html
@@ -521,7 +521,7 @@
                 line-height: 100%;
             }
 
-            .apple-link a {
+            a[x-apple-data-detectors] {
                 color: inherit !important;
                 font-family: inherit !important;
                 font-size: inherit !important;


### PR DESCRIPTION
The existing style was not properly targetting the links Apple inject when (wrongly, in this case) detecting phone numbers in newsletters.

This has no effect in any other platform or device.
The numbers are still clickable, couldn't fine a way to disable the functionality completely (tried the `format-detection` meta tag with no luck), but at least the styles are not changed anymore.

I tested this on iPhone and iPad and you can see how it looks before and after the change below.

### Before
![example1](https://user-images.githubusercontent.com/687910/96710015-61fca680-1393-11eb-9def-deff7c704564.png)
![example2](https://user-images.githubusercontent.com/687910/96710028-6628c400-1393-11eb-8ef0-ad247b5e0385.png)

### After
![example1b](https://user-images.githubusercontent.com/687910/96710043-6923b480-1393-11eb-8e4a-aed751c8020d.png)
![example2b](https://user-images.githubusercontent.com/687910/96710053-6cb73b80-1393-11eb-9e90-e9dc9a066768.png)
