### PR TITLE
Update reference link to CherryPy auth tool

### DIFF
--- a/plexpy/webauth.py
+++ b/plexpy/webauth.py
@@ -16,7 +16,6 @@
 #  along with Tautulli.  If not, see <http://www.gnu.org/licenses/>.
 
 
-# http://web.archive.org/web/20170210040849/http://tools.cherrypy.org/wiki/AuthenticationAndAccessRestrictions
 # https://github.com/cherrypy/tools/blob/master/AuthenticationAndAccessRestrictions
 # Form based authentication for CherryPy. Requires the
 # Session tool to be loaded.

--- a/plexpy/webauth.py
+++ b/plexpy/webauth.py
@@ -16,7 +16,8 @@
 #  along with Tautulli.  If not, see <http://www.gnu.org/licenses/>.
 
 
-# http://tools.cherrypy.org/wiki/AuthenticationAndAccessRestrictions
+# http://web.archive.org/web/20170210040849/http://tools.cherrypy.org/wiki/AuthenticationAndAccessRestrictions
+# https://github.com/cherrypy/tools/blob/master/AuthenticationAndAccessRestrictions
 # Form based authentication for CherryPy. Requires the
 # Session tool to be loaded.
 


### PR DESCRIPTION
Link is broken. Added two alternate links to the same information.