### PR TITLE
add most active libraries card and total plays to home

### DIFF
--- a/data/interfaces/default/home_stats.html
+++ b/data/interfaces/default/home_stats.html
@@ -112,7 +112,7 @@ DOCUMENTATION :: END
             % elif stat_id == 'most_concurrent':
             <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon stats-${stat_id} transparent hidden-xs"></div>
             % elif stat_id == 'top_libraries':
-            <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon library-${row0['type']} hidden-xs"></div>
+            <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon library-${row0['section_type']} hidden-xs"></div>
             % endif
             <div class="dashboard-stats-info-container">
                 <div id="stats-title-${stat_id}" class="dashboard-stats-info-title">
@@ -135,7 +135,7 @@ DOCUMENTATION :: END
                             % for row in top_stat['rows']:
                             <li class="dashboard-stats-info-item ${'expanded' if loop.index == 0 else ''}" data-stat_id="${stat_id}"
                                 data-rating_key="${row.get('rating_key')}" data-guid="${row.get('guid')}" data-title="${row.get('title')}"
-                                data-art="${row.get('art')}" data-thumb="${row.get('thumb')}" data-platform="${row.get('platform_name')}" data-library-type="${row.get('type')}"
+                                data-art="${row.get('art')}" data-thumb="${row.get('thumb')}" data-platform="${row.get('platform_name')}" data-library-type="${row.get('section_type')}"
                                 data-user_id="${row.get('user_id')}" data-user="${row.get('user')}" data-friendly_name="${row.get('friendly_name')}" data-user_thumb="${row.get('user_thumb')}"
                                 data-last_watch="${row.get('last_watch')}" data-started="${row.get('started')}" data-live="${row.get('live')}">
                                 <div class="sub-list">${loop.index + 1}</div>
@@ -162,7 +162,10 @@ DOCUMENTATION :: END
                                     % elif stat_id == 'most_concurrent':
                                     ${row['title']}
                                     % elif stat_id == 'top_libraries':
-                                    ${row['library_name']}
+                                    <% library_href = page('library', row['section_id']) %>
+                                    <a href="${library_href}" title="${row['section_name']}">
+                                        ${row['section_name']}
+                                    </a>
                                     % endif
                                 </div>
                                 <div class="sub-count">

--- a/data/interfaces/default/home_stats.html
+++ b/data/interfaces/default/home_stats.html
@@ -76,6 +76,8 @@ DOCUMENTATION :: END
         <div id="stats-background-${stat_id}" class="dashboard-stats-background" style="background-image: url(${page('pms_image_proxy', row0['art'], row0['rating_key'], 500, 280, 40, '282828', 3, fallback=fallback)});">
         % elif stat_id == 'top_platforms':
         <div id="stats-background-${stat_id}" class="dashboard-stats-background platform-${row0['platform_name']}-rgba no-image">
+        % elif stat_id == 'top_libraries':
+        <div id="stats-background-${stat_id}" class="dashboard-stats-background" style="background-image: url(${page('pms_image_proxy', row0['art'], None, 500, 280, 40, '282828', 3, fallback='art')});">
         % else:
         <div id="stats-background-${stat_id}" class="dashboard-stats-background flat">
         % endif
@@ -112,7 +114,11 @@ DOCUMENTATION :: END
             % elif stat_id == 'most_concurrent':
             <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon stats-${stat_id} transparent hidden-xs"></div>
             % elif stat_id == 'top_libraries':
-            <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon library-${row0['section_type']} hidden-xs"></div>
+                % if row0['thumb'].startswith('http'):
+                <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat hidden-xs" style="background-image: url(${page('pms_image_proxy', row0['thumb'], None, 80, 80)});"></div>
+                % else:
+                <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon library-${row0['section_type']} hidden-xs"></div>
+                % endif         
             % endif
             <div class="dashboard-stats-info-container">
                 <div id="stats-title-${stat_id}" class="dashboard-stats-info-title">

--- a/data/interfaces/default/home_stats.html
+++ b/data/interfaces/default/home_stats.html
@@ -25,7 +25,7 @@ grandparent_thumb       Returns location of the item's thumbnail. Use with pms_i
 rating_key              Returns the unique identifier for the media item.
 title                   Returns the title for the associated stat.
 
-== Only if 'stat_id' is 'top_tv' or 'top_movies' or 'top_music' or 'top_user' or 'top_platform' ==
+== Only if 'stat_id' is 'top_tv' or 'top_movies' or 'top_music' or 'top_user' or 'top_platform' or 'top_libraries' ==
 total_plays             Returns the count for the associated stat.
 total_duration          Returns the total duration for the associated stat.
 
@@ -111,6 +111,8 @@ DOCUMENTATION :: END
             <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon platform-${row0['platform_name']} transparent hidden-xs"></div>
             % elif stat_id == 'most_concurrent':
             <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon stats-${stat_id} transparent hidden-xs"></div>
+            % elif stat_id == 'top_libraries':
+            <div id="stats-thumb-${stat_id}" class="dashboard-stats-flat svg-icon library-${row0['type']} hidden-xs"></div>
             % endif
             <div class="dashboard-stats-info-container">
                 <div id="stats-title-${stat_id}" class="dashboard-stats-info-title">
@@ -133,7 +135,7 @@ DOCUMENTATION :: END
                             % for row in top_stat['rows']:
                             <li class="dashboard-stats-info-item ${'expanded' if loop.index == 0 else ''}" data-stat_id="${stat_id}"
                                 data-rating_key="${row.get('rating_key')}" data-guid="${row.get('guid')}" data-title="${row.get('title')}"
-                                data-art="${row.get('art')}" data-thumb="${row.get('thumb')}" data-platform="${row.get('platform_name')}"
+                                data-art="${row.get('art')}" data-thumb="${row.get('thumb')}" data-platform="${row.get('platform_name')}" data-library-type="${row.get('type')}"
                                 data-user_id="${row.get('user_id')}" data-user="${row.get('user')}" data-friendly_name="${row.get('friendly_name')}" data-user_thumb="${row.get('user_thumb')}"
                                 data-last_watch="${row.get('last_watch')}" data-started="${row.get('started')}" data-live="${row.get('live')}">
                                 <div class="sub-list">${loop.index + 1}</div>
@@ -159,6 +161,8 @@ DOCUMENTATION :: END
                                     ${row['platform']}
                                     % elif stat_id == 'most_concurrent':
                                     ${row['title']}
+                                    % elif stat_id == 'top_libraries':
+                                    ${row['library_name']}
                                     % endif
                                 </div>
                                 <div class="sub-count">

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -810,6 +810,10 @@
                 $('#stats-background-' + stat_id).removeClass(function (index, className) {
                     return (className.match (/(^|\s)platform-\S+/g) || []).join(' ');
                 }).addClass('platform-' + $(elem).data('platform') + '-rgba');
+            } else if (stat_id == 'top_libraries') {
+                $('#stats-thumb-' + stat_id).removeClass(function (index, className) {
+                    return (className.match (/(^|\s)library-\S+/g) || []).join(' ');
+                }).addClass('library-' + $(elem).data('library-type'));
             } else {
                 if (rating_key) {
                     if (live) {

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -783,6 +783,7 @@
             var art = $(elem).data('art');
             var thumb = $(elem).data('thumb');
             var user_id = $(elem).data('user_id');
+            var library_type = $(elem).data('library-type');
             var user_thumb = $(elem).data('user_thumb');
             var rating_key = $(elem).data('rating_key');
             var guid = $(elem).data('guid');
@@ -810,10 +811,16 @@
                 $('#stats-background-' + stat_id).removeClass(function (index, className) {
                     return (className.match (/(^|\s)platform-\S+/g) || []).join(' ');
                 }).addClass('platform-' + $(elem).data('platform') + '-rgba');
-            } else if (stat_id == 'top_libraries') {
+            } else if (stat_id === 'top_libraries') {
+                $('#stats-background-' + stat_id).css('background-image', 'url(' + page('pms_image_proxy', art, null, 500, 280, 40, '282828', 3, 'art') + ')');
                 $('#stats-thumb-' + stat_id).removeClass(function (index, className) {
-                    return (className.match (/(^|\s)library-\S+/g) || []).join(' ');
-                }).addClass('library-' + $(elem).data('library-type'));
+                    return (className.match (/(^|\s)svg-icon library-\S+/g) || []).join(' ')});
+                if (thumb.startsWith('http')) {
+                    $('#stats-thumb-' + stat_id).css('background-image', 'url(' + page('pms_image_proxy', thumb, null, 300, 300, null, null, null, 'cover') + ')');
+                } else {
+                    $('#stats-thumb-' + stat_id).css('background-image', '')
+                        .addClass('svg-icon library-' + library_type);
+                }
             } else {
                 if (rating_key) {
                     if (live) {

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -812,7 +812,7 @@
                     return (className.match (/(^|\s)platform-\S+/g) || []).join(' ');
                 }).addClass('platform-' + $(elem).data('platform') + '-rgba');
             } else if (stat_id === 'top_libraries') {
-                $('#stats-background-' + stat_id).css('background-image', 'url(' + page('pms_image_proxy', art, null, 500, 280, 40, '282828', 3, 'art') + ')');
+                $('#stats-background-' + stat_id).css('background-image', 'url(' + page('pms_image_proxy', art, null, 500, 280, 40, '282828', 3, fallback_art) + ')');
                 $('#stats-thumb-' + stat_id).removeClass(function (index, className) {
                     return (className.match (/(^|\s)svg-icon library-\S+/g) || []).join(' ')});
                 if (thumb.startsWith('http')) {

--- a/data/interfaces/default/library_stats.html
+++ b/data/interfaces/default/library_stats.html
@@ -19,6 +19,7 @@ thumb                   Returns the thumb of the library.
 count                   Returns the number of top level items in the library.
 parent_count            Returns the number of parent items in the library.
 child_count             Returns the number of child items in the library.
+total_plays             Returns the number of total plays of the library.
 
 DOCUMENTATION :: END
 </%doc>
@@ -28,9 +29,9 @@ DOCUMENTATION :: END
     from plexpy.helpers import page
 
     types = ('movie', 'show', 'artist', 'photo')
-    headers = {'movie': ('Movie Libraries', ('Movies', '', '')),
-               'show': ('TV Show Libraries', ('Shows', 'Seasons', 'Episodes')),
-               'artist': ('Music Libraries', ('Artists', 'Albums', 'Tracks')),
+    headers = {'movie': ('Movie Libraries', ('Movies', '', '', 'Total Plays')),
+               'show': ('TV Show Libraries', ('Shows', 'Seasons', 'Episodes', 'Total Plays')),
+               'artist': ('Music Libraries', ('Artists', 'Albums', 'Tracks', 'Total Plays')),
                'photo': ('Photo Libraries', ('Albums', 'Photos', 'Videos'))}
 %>
 % for section_type in types:
@@ -78,6 +79,12 @@ DOCUMENTATION :: END
                                 <div class="sub-divider"> / </div>
                                 <div class="sub-count">
                                     ${section['grandchild_count']}
+                                </div>
+                                % endif
+                                % if headers[section_type][1][3]:
+                                <div class="sub-divider"> / </div>
+                                <div class="sub-count">
+                                    ${section['total_plays']}
                                 </div>
                                 % endif
                             </li>

--- a/data/interfaces/default/library_stats.html
+++ b/data/interfaces/default/library_stats.html
@@ -19,7 +19,6 @@ thumb                   Returns the thumb of the library.
 count                   Returns the number of top level items in the library.
 parent_count            Returns the number of parent items in the library.
 child_count             Returns the number of child items in the library.
-total_plays             Returns the number of total plays of the library.
 
 DOCUMENTATION :: END
 </%doc>
@@ -29,9 +28,9 @@ DOCUMENTATION :: END
     from plexpy.helpers import page
 
     types = ('movie', 'show', 'artist', 'photo')
-    headers = {'movie': ('Movie Libraries', ('Movies', '', '', 'Total Plays')),
-               'show': ('TV Show Libraries', ('Shows', 'Seasons', 'Episodes', 'Total Plays')),
-               'artist': ('Music Libraries', ('Artists', 'Albums', 'Tracks', 'Total Plays')),
+    headers = {'movie': ('Movie Libraries', ('Movies', '', '')),
+               'show': ('TV Show Libraries', ('Shows', 'Seasons', 'Episodes')),
+               'artist': ('Music Libraries', ('Artists', 'Albums', 'Tracks')),
                'photo': ('Photo Libraries', ('Albums', 'Photos', 'Videos'))}
 %>
 % for section_type in types:
@@ -79,12 +78,6 @@ DOCUMENTATION :: END
                                 <div class="sub-divider"> / </div>
                                 <div class="sub-count">
                                     ${section['grandchild_count']}
-                                </div>
-                                % endif
-                                % if headers[section_type][1][3]:
-                                <div class="sub-divider"> / </div>
-                                <div class="sub-count">
-                                    ${section['total_plays']}
                                 </div>
                                 % endif
                             </li>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -406,6 +406,12 @@
                                         <li class="card card-sortable">
                                             <div class="card-handle"><i class="fa fa-bars"></i></div>
                                             <label>
+                                                <input type="checkbox" id="hscard-top_libraries" name="hscard-top_libraries" value="top_libraries"> Most Active Libraries
+                                            </label>
+                                        </li>
+                                        <li class="card card-sortable">
+                                            <div class="card-handle"><i class="fa fa-bars"></i></div>
+                                            <label>
                                                 <input type="checkbox" id="hscard-top_users" name="hscard-top_users" value="top_users"> Most Active User
                                             </label>
                                         </li>

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -557,3 +557,4 @@ class Config(object):
             self.HOME_STATS_CARDS = home_stats_cards
 
             self.CONFIG_VERSION = 18
+            

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -114,7 +114,7 @@ _CONFIG_DEFINITIONS = {
     'HOME_SECTIONS': (list, 'General', ['current_activity', 'watch_stats', 'library_stats', 'recently_added']),
     'HOME_LIBRARY_CARDS': (list, 'General', ['first_run']),
     'HOME_STATS_CARDS': (list, 'General', ['top_movies', 'popular_movies', 'top_tv', 'popular_tv', 'top_music',
-        'popular_music', 'last_watched', 'top_users', 'top_platforms', 'most_concurrent', 'top_libraries']),
+        'popular_music', 'last_watched', 'top_libraries', 'top_users', 'top_platforms', 'most_concurrent']),
     'HOME_REFRESH_INTERVAL': (int, 'General', 10),
     'HTTPS_CREATE_CERT': (int, 'General', 1),
     'HTTPS_CERT': (str, 'General', ''),
@@ -546,3 +546,14 @@ class Config(object):
                 self.PLEXPY_AUTO_UPDATE = 0
 
             self.CONFIG_VERSION = 17
+
+        if self.CONFIG_VERSION == 17:
+            home_stats_cards = self.HOME_STATS_CARDS
+            if 'top_users' in home_stats_cards:
+                top_users_index = home_stats_cards.index('top_users')
+                home_stats_cards.insert(top_users_index, 'top_libraries')
+            else:
+                home_stats_cards.add('top_libaries')
+            self.HOME_STATS_CARDS = home_stats_cards
+
+            self.CONFIG_VERSION = 18

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -114,7 +114,7 @@ _CONFIG_DEFINITIONS = {
     'HOME_SECTIONS': (list, 'General', ['current_activity', 'watch_stats', 'library_stats', 'recently_added']),
     'HOME_LIBRARY_CARDS': (list, 'General', ['first_run']),
     'HOME_STATS_CARDS': (list, 'General', ['top_movies', 'popular_movies', 'top_tv', 'popular_tv', 'top_music',
-        'popular_music', 'last_watched', 'top_users', 'top_platforms', 'most_concurrent']),
+        'popular_music', 'last_watched', 'top_users', 'top_platforms', 'most_concurrent', 'top_libraries']),
     'HOME_REFRESH_INTERVAL': (int, 'General', 10),
     'HTTPS_CREATE_CERT': (int, 'General', 1),
     'HTTPS_CERT': (str, 'General', ''),

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -942,7 +942,7 @@ class DataFactory(object):
                     'stat_type': sort_type,
                     'stat_title': 'Most Active Libraries',
                     'rows': session.mask_session_info(
-                        sorted(top_libraries, key=lambda k: k[sort_type], reverse=True),
+                        sorted(top_libraries, key=lambda k: k[sort_type], reverse=True)[:10],
                         mask_metadata=False)
                 })
 

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -950,11 +950,7 @@ class DataFactory(object):
             logger.warn("Tautulli DataFactory :: Unable to execute database query for get_library_stats: %s." % e)
             return None
 
-        library_data = libraries.Libraries()
-
         for item in result:
-            library_item = library_data.get_watch_time_stats(section_id=item['section_id'], grouping=None , query_days='0')
-
             if item['custom_thumb'] and item['custom_thumb'] != item['library_thumb']:
                 library_thumb = item['custom_thumb']
             elif item['library_thumb']:
@@ -974,8 +970,7 @@ class DataFactory(object):
                        'art': library_art,
                        'count': item['count'],
                        'child_count': item['parent_count'],
-                       'grandchild_count': item['child_count'],
-                       'total_plays': library_item[0]['total_plays']
+                       'grandchild_count': item['child_count']
                        }
             library_stats.append(library)
 

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -894,8 +894,10 @@ class DataFactory(object):
                 top_libraries = []
 
                 try:
-                    query = 'SELECT section_id, section_name, section_type ' \
-                        'FROM library_sections'
+                    query = 'SELECT section_id, section_name, section_type, thumb AS library_thumb, ' \
+                        'custom_thumb_url AS custom_thumb, art AS library_art, custom_art_url AS custom_art ' \
+                        'FROM library_sections ' \
+                        'WHERE deleted_section = 0'
 
                     result = monitor_db.select(query)
                 except Exception as e:
@@ -907,11 +909,27 @@ class DataFactory(object):
                 for item in result:
                     library_item = library_data.get_watch_time_stats(section_id=item['section_id'], grouping=None , query_days=time_range)
 
+                    if item['custom_thumb'] and item['custom_thumb'] != item['library_thumb']:
+                        library_thumb = item['custom_thumb']
+                    elif item['library_thumb']:
+                        library_thumb = item['library_thumb']
+                    else:
+                        library_thumb = common.DEFAULT_COVER_THUMB
+
+                    if item['custom_art'] and item['custom_art'] != item['library_art']:
+                        library_art = item['custom_art']
+                    else:
+                        library_art = item['library_art']
+
                     row = {
                         'total_plays': library_item[0]['total_plays'],
                         'total_duration': library_item[0]['total_time'],
-                        'type': item['section_type'],
-                        'library_name': item['section_name']
+                        'section_type': item['section_type'],
+                        'section_name': item['section_name'],
+                        'section_id': item['section_id'],
+                        'last_play': '',
+                        'thumb': library_thumb,
+                        'art': library_art
                     }
 
                     top_libraries.append(row)

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 # This file is part of Tautulli.
 #
@@ -895,9 +895,9 @@ class DataFactory(object):
 
                 try:
                     query = 'SELECT section_id, section_name, section_type, thumb AS library_thumb, ' \
-                        'custom_thumb_url AS custom_thumb, art AS library_art, custom_art_url AS custom_art ' \
-                        'FROM library_sections ' \
-                        'WHERE deleted_section = 0'
+                            'custom_thumb_url AS custom_thumb, art AS library_art, custom_art_url AS custom_art ' \
+                            'FROM library_sections ' \
+                            'WHERE deleted_section = 0'
 
                     result = monitor_db.select(query)
                 except Exception as e:
@@ -907,7 +907,8 @@ class DataFactory(object):
                 library_data = libraries.Libraries()
 
                 for item in result:
-                    library_item = library_data.get_watch_time_stats(section_id=item['section_id'], grouping=None , query_days=time_range)
+                    library_item = library_data.get_watch_time_stats(section_id=item['section_id'],
+                                                                     query_days=time_range)
 
                     if not library_item or library_item[0]['total_plays'] == 0 and library_item[0]['total_time'] == 0:
                         continue

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -909,6 +909,9 @@ class DataFactory(object):
                 for item in result:
                     library_item = library_data.get_watch_time_stats(section_id=item['section_id'], grouping=None , query_days=time_range)
 
+                    if library_item[0]['total_plays'] == 0 and library_item[0]['total_time'] == 0:
+                        continue
+
                     if item['custom_thumb'] and item['custom_thumb'] != item['library_thumb']:
                         library_thumb = item['custom_thumb']
                     elif item['library_thumb']:
@@ -938,7 +941,9 @@ class DataFactory(object):
                     'stat_id': stat,
                     'stat_type': sort_type,
                     'stat_title': 'Most Active Libraries',
-                    'rows': session.mask_session_info(sorted(top_libraries, key=lambda k: k[sort_type], reverse=True), mask_metadata=False)
+                    'rows': session.mask_session_info(
+                        sorted(top_libraries, key=lambda k: k[sort_type], reverse=True),
+                        mask_metadata=False)
                 })
 
         if stat_id and home_stats:

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 # This file is part of Tautulli.
 #
@@ -909,7 +909,7 @@ class DataFactory(object):
                 for item in result:
                     library_item = library_data.get_watch_time_stats(section_id=item['section_id'], grouping=None , query_days=time_range)
 
-                    if library_item[0]['total_plays'] == 0 and library_item[0]['total_time'] == 0:
+                    if not library_item or library_item[0]['total_plays'] == 0 and library_item[0]['total_time'] == 0:
                         continue
 
                     if item['custom_thumb'] and item['custom_thumb'] != item['library_thumb']:

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -4665,7 +4665,7 @@ class WebInterface(object):
             else:
                 img = '/library/metadata/{}/thumb'.format(rating_key)
 
-        if img:
+        if img and not img.startswith('http'):
             parts = 5
             if img.startswith('/playlists'):
                 parts -= 1


### PR DESCRIPTION
## Description

Addition of a home card called "Most Active Libraries" which shows the total plays/duration of a library in the selected time period (days).
The card is sorted by highest amount of plays/duration for the libraries.
The picture changes, when hovering over a library name, according to the library type.

Addition of a total play count (not affected by choosen time period) directly in the Library Statistics of the home page for all library types (excluding photos). As a side-result a easy comparison between, plays for a time period and in total for a library, is now possible on one page.

![tautulli_most_active_libraries](https://user-images.githubusercontent.com/12448284/109559013-6e7bd300-7ada-11eb-86f5-b1cc8f03d770.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
