### PR TITLE
MQTT improvements

### DIFF
--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -1883,6 +1883,25 @@ Rating: {rating}/10   --> Rating: /10
 {Rating: &lt;rating&gt;/10} --> </pre>
                     </div>
                     <div>
+                        <h4>JSON</h4>
+                    </div>
+                    <div style="padding-bottom: 10px;">
+                        <p class="help-block">
+                            Notification parameters with the <span class="inline-pre">!j</span> modifier will be dumped as a JSON string.
+                            Note that if you want to include literal braces in your body (to build a JSON object), they will need to be
+                            doubled to avoid them being interpreted as parameter references.
+                        </p>
+                        <p><strong style="color: #fff;">Example:</strong></p>
+                        <pre>{player}              --> John's "Theater"
+{player!j}            --> "John's \"Theater\"" </pre>
+                        <p><strong style="color: #fff;">Example building full JSON object:</strong></p>
+                        <pre>{{ "title": {title!j},
+ "media_type": {media_type!j} }}       -->
+
+{ "title": "Paw Patrol - Pups Save a School Day",
+  "media_type": "episode" } </pre>
+                    </div>
+                    <div>
                         <h4>Combined</h4>
                     </div>
                     <div>
@@ -1892,7 +1911,7 @@ Rating: {rating}/10   --> Rating: /10
                         <ol class="help-block">
                             <li>Prefix</li>
                             <li>Parameter</li>
-                            <li>Case Modifier</li>
+                            <li>Case Modifier/JSON</li>
                             <li>List Slicing</li>
                             <li>Suffix</li>
                         </ol>

--- a/plexpy/notification_handler.py
+++ b/plexpy/notification_handler.py
@@ -1783,6 +1783,8 @@ class CustomFormatter(Formatter):
             return str(value).lower()
         elif conversion == 'c':  # capitalize
             return str(value).title()
+        elif conversion == 'j': # JSON
+            return json.dumps(str(value))
         else:
             return value
 


### PR DESCRIPTION
## Description

This is a series of changes to improve the machine readability of notifications sent via MQTT. In particular, being able to send to multiple topics based on any parameter (i.e. I plan to include the {player_id} in the topic so that if I want to do automations for what's happening in a particular room, I only have to subscribe to that topic), and being able to either send bare 
text not wrapped in JSON for simpler handling at the recipient OR being able to build a full JSON object with proper escaping to bundle a lot of information in a single notification.

Fixes #1415 and #1416.

A couple of notes:
 * I'm more than willing to split each commit into its own PR if you would prefer to review that way.
 * I didn't love the deferred import of build_notify_text, but it was necessary to avoid a circular dependency. Possibly break that method out into a separate module? Also, possibly refactor it so that it doesn't need to do repetitive work on both subject and body, and just call it twice.
 * It might make more sense to just have the subject correspond to the MQTT topic, and the body the payload, but that would be a breaking change (there would no longer be a topic configuration setting at all). This would also eliminate the need for the omit_subject option.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
