### PR TITLE
Config for CheryPy Thread Pool Size

### DIFF
--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -137,6 +137,7 @@ _CONFIG_DEFINITIONS = {
     'HTTP_RATE_LIMIT_ATTEMPTS': (int, 'General', 10),
     'HTTP_RATE_LIMIT_ATTEMPTS_INTERVAL': (int, 'General', 300),
     'HTTP_RATE_LIMIT_LOCKOUT_TIME': (int, 'General', 300),
+    'HTTP_THREAD_POOL': (int, 'General', 10),
     'INTERFACE': (str, 'General', 'default'),
     'IMGUR_CLIENT_ID': (str, 'Monitoring', ''),
     'JOURNAL_MODE': (str, 'Advanced', 'WAL'),

--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -88,7 +88,7 @@ def initialize(options):
         'server.socket_port': options['http_port'],
         'server.socket_host': options['http_host'],
         'environment': options['http_environment'],
-        'server.thread_pool': 10,
+        'server.thread_pool': plexpy.CONFIG.HTTP_THREAD_POOL,
         'server.max_request_body_size': 1073741824,
         'server.socket_timeout': 60,
         'tools.encode.on': True,
@@ -135,6 +135,7 @@ def initialize(options):
     else:
         plexpy.HTTP_ROOT = options['http_root'] = '/'
 
+    logger.info("Tautulli WebStart :: Thread Pool Size: %d.", plexpy.CONFIG.HTTP_THREAD_POOL)
     cherrypy.config.update(options_dict)
 
     conf = {


### PR DESCRIPTION
In some instances, a static thread pool size of 10 is too small.
Provide a way to modify this via the config.all for large servers

## Description

This fixes quite a lot of http accept stalls due to lack of resources.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
