### PR TITLE
Use maxOffsetAvailable for transcoder progress

### DIFF
--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -1732,7 +1732,11 @@ class PmsConnect(object):
 
             transcode_info = session.getElementsByTagName('TranscodeSession')[0]
 
-            transcode_progress = helpers.get_xml_attr(transcode_info, 'progress')
+            # transcode_info's 'progress' field is relative to the transcode's starting point, so will be inaccurate if an
+            # item is resumed partway through. Instead calculate the percentage using the maxOffsetAvailable and duration.
+            transcode_max_offset = helpers.cast_to_float(helpers.get_xml_attr(transcode_info, 'maxOffsetAvailable'))
+            transcode_duration = helpers.cast_to_float(helpers.get_xml_attr(transcode_info, 'duration'))
+            transcode_progress = ((transcode_max_offset * 1000) / transcode_duration) * 100
             transcode_speed = helpers.get_xml_attr(transcode_info, 'speed')
 
             transcode_details = {'transcode_key': helpers.get_xml_attr(transcode_info, 'key'),


### PR DESCRIPTION
## Description

TranscodeSession's `progress` field indicates its progress relative to the point it started transcoding from. So if a movie starts 50% of the way through and the transcoder has transcoded from 50% to 55%, it will report 5%. When displaying progress bars though, we're more interested in the maximum point of the transcoder, so instead use a combination of the duration of the item and `maxOffsetAvailable` to calculate the "real" progress of the transcoder.

### Screenshot

![image](https://user-images.githubusercontent.com/7410989/153772605-02293738-e554-4af9-82d3-0211abc32ec3.png)

Start an item (and immediately pause) 18% of the way through. Wait for the transcode to progress.
**Left**: Old behavior. Don't see a transcode progress bar until the transcode itself is 18% of the way through.
**Right**: New behavior. Transcode progress is based on `maxOffsetAvailabe`, so immediately shows progress.
Note that the transcode progress with the old behavior is the sum of the transcode progress of the old behavior plus the progress.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
