### PR TITLE
Total element count by Library Type on Homepage

### DIFF
--- a/data/interfaces/default/library_stats.html
+++ b/data/interfaces/default/library_stats.html
@@ -59,9 +59,13 @@ DOCUMENTATION :: END
                                 data-art="${section.get('art')}" data-thumb="${section.get('thumb')}">
                                 <div class="sub-list">${loop.index + 1}</div>
                                 <div class="sub-value">
+                                    % if section['section_id'] == '0':
+                                    ${section['section_name']}
+                                    % else:
                                     <a href="${page('library', section['section_id'])}" title="${section['section_name']}">
                                         ${section['section_name']}
                                     </a>
+                                    % endif
                                 </div>
                                 % if headers[section_type][1][0]:
                                 <div class="sub-count">

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -497,9 +497,9 @@
 
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="total_element_count" name="total_element_count" value="0" ${config['total_element_count']}> Total for Library Type
+                                <input type="checkbox" id="total_element_count" name="total_element_count" value="0" ${config['total_element_count']}> Total Count by Library Type
                             </label>
-                            <p class="help-block">Enable to have the total number of elements for this library type listed in each library statistics card.</p>
+                            <p class="help-block">Enable to have the total number of elements for this library type listed in the corresponding library statistics card.</p>
                         </div>
 
                         <p><input type="button" class="btn btn-bright save-button" value="Save" data-success="Changes saved successfully"></p>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -495,6 +495,13 @@
                             </div>
                         </div>
 
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" id="total_element_count" name="total_element_count" value="0" ${config['total_element_count']}> Total for Library Type
+                            </label>
+                            <p class="help-block">Enable to have the total number of elements for this library type listed in each library statistics card.</p>
+                        </div>
+
                         <p><input type="button" class="btn btn-bright save-button" value="Save" data-success="Changes saved successfully"></p>
 
                     </div>

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -191,6 +191,7 @@ _CONFIG_DEFINITIONS = {
     'SYNCHRONOUS_MODE': (str, 'Advanced', 'NORMAL'),
     'THEMOVIEDB_APIKEY': (str, 'General', 'e9a6655bae34bf694a0f3e33338dc28e'),
     'THEMOVIEDB_LOOKUP': (int, 'General', 0),
+    'TOTAL_ELEMENT_COUNT': (int, 'Monitoring', 0), 
     'TVMAZE_LOOKUP': (int, 'General', 0),
     'TV_WATCHED_PERCENT': (int, 'Monitoring', 85),
     'UPDATE_DB_INTERVAL': (int, 'General', 24),
@@ -335,6 +336,7 @@ CHECKED_SETTINGS = [
     'REFRESH_USERS_ON_STARTUP',
     'SYS_TRAY_ICON',
     'THEMOVIEDB_LOOKUP',
+    'TOTAL_ELEMENT_COUNT',
     'TVMAZE_LOOKUP',
     'WEEK_START_MONDAY',
 ]
@@ -704,3 +706,8 @@ class Config(object):
                 self.FIRST_RUN_COMPLETE = 1
 
             self.CONFIG_VERSION = 21
+
+        if self.CONFIG_VERSION == 21:
+            self.TOTAL_ELEMENT_COUNT = 0
+      
+            self.CONFIG_VERSION = 22

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1044,7 +1044,6 @@ class DataFactory(object):
                     total_child_count = total_child_count + library['child_count'] if library['child_count'] != None else total_child_count
                     total_grandchild_count = total_grandchild_count + library['grandchild_count'] if library['grandchild_count'] != None else total_grandchild_count
                 
-                #Set the art and thumb to tautulli default -> How to best access it?
                 _library = {'section_id': '0',
                         'section_name': 'Total',
                         'section_type': type,

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1048,6 +1048,8 @@ class DataFactory(object):
                 _library = {'section_id': '0',
                         'section_name': 'Total',
                         'section_type': type,
+                        'thumb': common.DEFAULT_COVER_THUMB,
+                        'art': common.DEFAULT_ART,
                         'count': total_count,
                         'child_count': total_child_count,
                         'grandchild_count': total_grandchild_count

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1031,6 +1031,30 @@ class DataFactory(object):
 
         library_stats = {k: list(v) for k, v in groupby(library_stats, key=lambda x: x['section_type'])}
 
+        if plexpy.CONFIG.TOTAL_ELEMENT_COUNT:        
+            for type in library_stats:
+                total_count = 0
+                total_child_count = 0
+                total_grandchild_count = 0
+
+                _libraries = library_stats.get(type)
+
+                for library in _libraries:
+                    total_count = total_count + library['count'] if library['count'] != None else total_count
+                    total_child_count = total_child_count + library['child_count'] if library['child_count'] != None else total_child_count
+                    total_grandchild_count = total_grandchild_count + library['grandchild_count'] if library['grandchild_count'] != None else total_grandchild_count
+                
+                #Set the art and thumb to tautulli default -> How to best access it?
+                _library = {'section_id': '0',
+                        'section_name': 'Total',
+                        'section_type': type,
+                        'count': total_count,
+                        'child_count': total_child_count,
+                        'grandchild_count': total_grandchild_count
+                        }
+                
+                _libraries.append(_library)
+
         return library_stats
 
     def get_watch_time_stats(self, rating_key=None, grouping=None, query_days=None):


### PR DESCRIPTION
## Description

This feature introduces the option to enable/disable a combined count of elements for each Library Statistics card. _So for each media type._
The feature is disabled by default and can be activated in a new corresponding setting.

Based on issue #1621 .

### Screenshot

**Homepage**
![tautulli-total-element-count-homepage](https://user-images.githubusercontent.com/12448284/153878198-08a5f120-b31d-40a2-b915-108951272db3.png)

**Settings**
![tautulli-total-element-count-setting](https://user-images.githubusercontent.com/12448284/153878188-2ea95850-4838-4f1d-b55c-64b52b62bc2f.png)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
