### PR TITLE
Video Profile (e.g. HDR) listed in Media Info

### DIFF
--- a/data/interfaces/default/js/tables/media_info_table.js
+++ b/data/interfaces/default/js/tables/media_info_table.js
@@ -175,7 +175,7 @@ media_info_table_options = {
         },
         {
             "targets": [6],
-            "data": "video_framerate",
+            "data": "video_profile",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
                     $(td).html(cellData);
@@ -186,7 +186,7 @@ media_info_table_options = {
         },
         {
             "targets": [7],
-            "data": "audio_codec",
+            "data": "video_framerate",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
                     $(td).html(cellData);
@@ -197,6 +197,17 @@ media_info_table_options = {
         },
         {
             "targets": [8],
+            "data": "audio_codec",
+            "createdCell": function (td, cellData, rowData, row, col) {
+                if (cellData !== null && cellData !== '') {
+                    $(td).html(cellData);
+                }
+            },
+            "width": "8%",
+            "className": "no-wrap"
+        },
+        {
+            "targets": [9],
             "data": "audio_channels",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
@@ -207,7 +218,7 @@ media_info_table_options = {
             "className": "no-wrap"
         },
         {
-            "targets": [9],
+            "targets": [10],
             "data": "file_size",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
@@ -223,7 +234,7 @@ media_info_table_options = {
             "searchable": false
         },
         {
-            "targets": [10],
+            "targets": [11],
             "data": "last_played",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
@@ -236,7 +247,7 @@ media_info_table_options = {
             "searchable": false
         },
         {
-            "targets": [11],
+            "targets": [12],
             "data": "play_count",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
@@ -453,6 +464,7 @@ function childTableFormatMedia(rowData) {
                 '<th align="left" id="bitrate">Bitrate</th>' +
                 '<th align="left" id="video_codec">Video Codec</th>' +
                 '<th align="left" id="video_resolution">Video Resolution</th>' +
+                '<th align="left" id="video_profile">Video Profile</th>' +
                 '<th align="left" id="video_resolution">Video Framerate</th>' +
                 '<th align="left" id="audio_codec">Audio Codec</th>' +
                 '<th align="left" id="audio_channels">Audio Channels</th>' +

--- a/data/interfaces/default/js/tables/media_info_table.js
+++ b/data/interfaces/default/js/tables/media_info_table.js
@@ -175,7 +175,7 @@ media_info_table_options = {
         },
         {
             "targets": [6],
-            "data": "video_profile",
+            "data": "video_dynamic_range",
             "createdCell": function (td, cellData, rowData, row, col) {
                 if (cellData !== null && cellData !== '') {
                     $(td).html(cellData);
@@ -464,7 +464,7 @@ function childTableFormatMedia(rowData) {
                 '<th align="left" id="bitrate">Bitrate</th>' +
                 '<th align="left" id="video_codec">Video Codec</th>' +
                 '<th align="left" id="video_resolution">Video Resolution</th>' +
-                '<th align="left" id="video_profile">Video Profile</th>' +
+                '<th align="left" id="video_dynamic_range">Video Dyn. Range</th>' +
                 '<th align="left" id="video_resolution">Video Framerate</th>' +
                 '<th align="left" id="audio_codec">Audio Codec</th>' +
                 '<th align="left" id="audio_channels">Audio Channels</th>' +

--- a/data/interfaces/default/library.html
+++ b/data/interfaces/default/library.html
@@ -306,7 +306,7 @@ DOCUMENTATION :: END
                                                     <th align="left" id="bitrate">Bitrate</th>
                                                     <th align="left" id="video_codec">Video Codec</th>
                                                     <th align="left" id="video_resolution">Video Resolution</th>
-                                                    <th align="left" id="video_profile">Video Profile</th>
+                                                    <th align="left" id="video_dynamic_range">Video Dyn. Range</th>
                                                     <th align="left" id="video_resolution">Video Framerate</th>
                                                     <th align="left" id="audio_codec">Audio Codec</th>
                                                     <th align="left" id="audio_channels">Audio Channels</th>

--- a/data/interfaces/default/library.html
+++ b/data/interfaces/default/library.html
@@ -306,6 +306,7 @@ DOCUMENTATION :: END
                                                     <th align="left" id="bitrate">Bitrate</th>
                                                     <th align="left" id="video_codec">Video Codec</th>
                                                     <th align="left" id="video_resolution">Video Resolution</th>
+                                                    <th align="left" id="video_profile">Video Profile</th>
                                                     <th align="left" id="video_resolution">Video Framerate</th>
                                                     <th align="left" id="audio_codec">Audio Codec</th>
                                                     <th align="left" id="audio_channels">Audio Channels</th>

--- a/plexpy/helpers.py
+++ b/plexpy/helpers.py
@@ -1545,7 +1545,7 @@ def is_hdr(bit_depth, color_space):
 
 
 def version_to_tuple(version):
-    return tuple(cast_to_int(v) for v in version.strip('v').split('.'))
+    return tuple(cast_to_int(v) for v in version.strip('v').replace('-', '.').split('.'))
 
 
 # https://stackoverflow.com/a/1855118

--- a/plexpy/libraries.py
+++ b/plexpy/libraries.py
@@ -582,7 +582,7 @@ class Libraries(object):
                        'bitrate': item.get('bitrate', ''),
                        'video_codec': item.get('video_codec', ''),
                        'video_resolution': item.get('video_resolution', ''),
-                       'video_profile': item.get('video_profile', ''),
+                       'video_dynamic_range': item.get('video_dynamic_range', ''),
                        'video_framerate': item.get('video_framerate', ''),
                        'audio_codec': item.get('audio_codec', ''),
                        'audio_channels': item.get('audio_channels', ''),

--- a/plexpy/libraries.py
+++ b/plexpy/libraries.py
@@ -16,6 +16,8 @@
 #  along with Tautulli.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+
+from sqlalchemy import true
 from future.builtins import str
 from future.builtins import next
 from future.builtins import object
@@ -582,6 +584,7 @@ class Libraries(object):
                        'bitrate': item.get('bitrate', ''),
                        'video_codec': item.get('video_codec', ''),
                        'video_resolution': item.get('video_resolution', ''),
+                       'video_profile': item.get('video_profile', ''),
                        'video_framerate': item.get('video_framerate', ''),
                        'audio_codec': item.get('audio_codec', ''),
                        'audio_channels': item.get('audio_channels', ''),

--- a/plexpy/libraries.py
+++ b/plexpy/libraries.py
@@ -16,8 +16,6 @@
 #  along with Tautulli.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
-
-from sqlalchemy import true
 from future.builtins import str
 from future.builtins import next
 from future.builtins import object

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -2721,7 +2721,7 @@ class PmsConnect(object):
                     for media in item_media:
                         _videoProfile = helpers.get_xml_attr(media, 'videoProfile')
                         if _videoProfile == 'main 10':
-                            media_metadata = PmsConnect().get_metadata(
+                            media_metadata = self.get_metadata(
                                 str(helpers.get_xml_attr(item, 'ratingKey')), output_format='xml')
                             _stream = media_metadata.getElementsByTagName('Stream')[0]
                             if _stream.hasAttribute('DOVIProfile'):

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -2723,6 +2723,7 @@ class PmsConnect(object):
                                       'bitrate': helpers.get_xml_attr(media, 'bitrate'),
                                       'video_codec': helpers.get_xml_attr(media, 'videoCodec'),
                                       'video_resolution': helpers.get_xml_attr(media, 'videoResolution').lower(),
+                                      'video_profile': helpers.get_xml_attr(media, 'videoProfile'),
                                       'video_framerate': helpers.get_xml_attr(media, 'videoFrameRate'),
                                       'audio_codec': helpers.get_xml_attr(media, 'audioCodec'),
                                       'audio_channels': helpers.get_xml_attr(media, 'audioChannels'),

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -2719,11 +2719,21 @@ class PmsConnect(object):
                 if get_media_info:
                     item_media = item.getElementsByTagName('Media')
                     for media in item_media:
+                        _videoProfile = helpers.get_xml_attr(media, 'videoProfile')
+                        if _videoProfile == 'main 10':
+                            media_metadata = PmsConnect().get_metadata(
+                                str(helpers.get_xml_attr(item, 'ratingKey')), output_format='xml')
+                            _stream = media_metadata.getElementsByTagName('Stream')[0]
+                            if _stream.hasAttribute('DOVIProfile'):
+                                _videoProfile = 'main 10 HDR DV'
+                            else: 
+                                _videoProfile = 'main 10 HDR'
+
                         media_info = {'container': helpers.get_xml_attr(media, 'container'),
                                       'bitrate': helpers.get_xml_attr(media, 'bitrate'),
                                       'video_codec': helpers.get_xml_attr(media, 'videoCodec'),
                                       'video_resolution': helpers.get_xml_attr(media, 'videoResolution').lower(),
-                                      'video_profile': helpers.get_xml_attr(media, 'videoProfile'),
+                                      'video_profile': _videoProfile,
                                       'video_framerate': helpers.get_xml_attr(media, 'videoFrameRate'),
                                       'audio_codec': helpers.get_xml_attr(media, 'audioCodec'),
                                       'audio_channels': helpers.get_xml_attr(media, 'audioChannels'),

--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -2726,8 +2726,13 @@ class PmsConnect(object):
                             _stream = media_metadata.getElementsByTagName('Stream')[0]
                             if _stream.hasAttribute('DOVIProfile'):
                                 _videoProfile = 'main 10 HDR DV'
-                            else: 
+                            elif _stream.hasAttribute('chromaLocation') and (_stream.getAttribute('colorTrc') == 'bt2020-10' 
+                                    or _stream.getAttribute('colorTrc') == 'arib-std-b67'):
+                                _videoProfile = 'main 10 HDR HLG'
+                            elif helpers.cast_to_int(_stream.getAttribute('bitDepth')) > 8 and _stream.getAttribute('colorSpace') == 'bt2020nc':
                                 _videoProfile = 'main 10 HDR'
+                            else:
+                                _videoProfile = 'main 10 SDR'
 
                         media_info = {'container': helpers.get_xml_attr(media, 'container'),
                                       'bitrate': helpers.get_xml_attr(media, 'bitrate'),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -824,7 +824,7 @@ class WebInterface(object):
                           ("bitrate", True, True),
                           ("video_codec", True, True),
                           ("video_resolution", True, True),
-                          ("video_profile", True, True),
+                          ("video_dynamic_range", True, True),
                           ("video_framerate", True, True),
                           ("audio_codec", True, True),
                           ("audio_channels", True, True),

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -824,6 +824,7 @@ class WebInterface(object):
                           ("bitrate", True, True),
                           ("video_codec", True, True),
                           ("video_resolution", True, True),
+                          ("video_profile", True, True),
                           ("video_framerate", True, True),
                           ("audio_codec", True, True),
                           ("audio_channels", True, True),


### PR DESCRIPTION
## Description

This feature adds the video profile as a column to the media info of a library.
_The column can be selected/deselected as usual (see screenshot)._

_This feature is based on the idea mentioned in issue #1475 ._

### Screenshot
![tautulli-hdr-profile-media_info_example](https://user-images.githubusercontent.com/12448284/153919553-05a632a8-a836-48e2-b41c-3a1dcb07016d.png)
_Example of two 4K movies with the `video profile` listed between the `video resolution` and the `video framerate`._

![tautulli-hdr-profile-media_info](https://user-images.githubusercontent.com/12448284/153919577-5e07d979-1dcb-4f95-99a3-745aca5d6acb.png) ![tautulli-hdr-profile-media_info_select_column](https://user-images.githubusercontent.com/12448284/153919593-e8a8c37d-c12d-4f3d-a67f-0268095f1fca.png)
_Broader example of different `video profiles` and the option to select/deselect the column._

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
