### PR TITLE
MQTT improvements

### DIFF
--- a/plexpy/notification_handler.py
+++ b/plexpy/notification_handler.py
@@ -402,7 +402,8 @@ def notify(notifier_id=None, notify_action=None, stream_data=None, timeline_data
                                                        body=body_string,
                                                        notify_action=notify_action,
                                                        parameters=parameters,
-                                                       agent_id=notifier_config['agent_id'])
+                                                       agent_id=notifier_config['agent_id'],
+                                                       as_json=notifier_config['config']['as_json'])
 
     # Set the notification state in the db
     notification_id = set_notify_state(session=stream_data or timeline_data,
@@ -1259,7 +1260,7 @@ def build_server_notify_params(notify_action=None, **kwargs):
     return available_params
 
 
-def build_notify_text(subject='', body='', notify_action=None, parameters=None, agent_id=None, test=False):
+def build_notify_text(subject='', body='', notify_action=None, parameters=None, agent_id=None, test=False, as_json=False):
     # Default subject and body text
     if agent_id == 15:
         default_subject = default_body = ''
@@ -1320,7 +1321,7 @@ def build_notify_text(subject='', body='', notify_action=None, parameters=None, 
             logger.exception("Tautulli NotificationHandler :: Unable to parse custom script arguments: %s. Using fallback." % e)
             script_args = []
 
-    elif agent_id == 25:
+    elif agent_id == 25 or as_json:
         if subject:
             try:
                 subject = json.loads(subject)

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -2370,14 +2370,18 @@ class MQTT(Notifier):
                        'keep_alive': 60
                        }
 
-    def agent_notify(self, subject='', body='', action='', **kwargs):
-        if not self.config['topic']:
+    def agent_notify(self, subject='', body='', action='', parameters={}, **kwargs):
+        topic = self.config['topic']
+        if not topic:
             logger.error("Tautulli Notifiers :: MQTT topic not specified.")
             return
 
+        # format the topic
+        topic = topic.format(**parameters)
+
         data = {'subject': subject,
                 'body': body,
-                'topic': self.config['topic']}
+                'topic': topic}
 
         auth = {}
         if self.config['username']:
@@ -2390,7 +2394,7 @@ class MQTT(Notifier):
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
 
         paho.mqtt.publish.single(
-            self.config['topic'], payload=json.dumps(data), qos=self.config['qos'], retain=bool(self.config['retain']),
+            topic, payload=json.dumps(data), qos=self.config['qos'], retain=bool(self.config['retain']),
             hostname=self.config['broker'], port=self.config['port'], client_id=self.config['clientid'],
             keepalive=self.config['keep_alive'], auth=auth or None, protocol=protocol
         )
@@ -2443,7 +2447,7 @@ class MQTT(Notifier):
                          {'label': 'Topic',
                           'value': self.config['topic'],
                           'name': 'mqtt_topic',
-                          'description': 'The topic to publish notifications to.',
+                          'description': 'The topic to publish notifications to. Can be dynamic by including parameters just like the message body.',
                           'input_type': 'text'
                           },
                          {'label': 'Quality of Service',

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -2367,7 +2367,8 @@ class MQTT(Notifier):
                        'topic': '',
                        'qos': 1,
                        'retain': 0,
-                       'keep_alive': 60
+                       'keep_alive': 60,
+                       'incl_subject': 1
                        }
 
     def agent_notify(self, subject='', body='', action='', parameters={}, **kwargs):
@@ -2379,9 +2380,12 @@ class MQTT(Notifier):
         # format the topic
         topic = topic.format(**parameters)
 
-        data = {'subject': subject,
-                'body': body,
-                'topic': topic}
+        if self.config['incl_subject']:
+            data = json.dumps({'subject': subject,
+                               'body': body,
+                               'topic': topic})
+        else:
+            data = body
 
         auth = {}
         if self.config['username']:
@@ -2394,7 +2398,7 @@ class MQTT(Notifier):
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
 
         paho.mqtt.publish.single(
-            topic, payload=json.dumps(data), qos=self.config['qos'], retain=bool(self.config['retain']),
+            topic, payload=data, qos=self.config['qos'], retain=bool(self.config['retain']),
             hostname=self.config['broker'], port=self.config['port'], client_id=self.config['clientid'],
             keepalive=self.config['keep_alive'], auth=auth or None, protocol=protocol
         )
@@ -2471,7 +2475,16 @@ class MQTT(Notifier):
                           'name': 'mqtt_keep_alive',
                           'description': 'Maximum period in seconds before timing out the connection with the broker.',
                           'input_type': 'number'
-                          }
+                          },
+                         {'label': 'Include Subject',
+                          'value': self.config['incl_subject'],
+                          'name': 'mqtt_incl_subject',
+                          'description': 'Include the subject in the MQTT message.<br>'
+                                         'The default is to wrap the notification subject and body in a JSON object, '
+                                         'and send that as the MQTT payload. By unchecking this option, the body will '
+                                         'be sent as the bare payload, with no additional escaping.',
+                          'input_type': 'checkbox'
+                          },
                          ]
 
         return config_option

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -2368,7 +2368,8 @@ class MQTT(Notifier):
                        'qos': 1,
                        'retain': 0,
                        'keep_alive': 60,
-                       'incl_subject': 1
+                       'incl_subject': 1,
+                       'as_json': 0
                        }
 
     def agent_notify(self, subject='', body='', action='', parameters={}, **kwargs):
@@ -2483,6 +2484,12 @@ class MQTT(Notifier):
                                          'The default is to wrap the notification subject and body in a JSON object, '
                                          'and send that as the MQTT payload. By unchecking this option, the body will '
                                          'be sent as the bare payload, with no additional escaping.',
+                          'input_type': 'checkbox'
+                          },
+                         {'label': 'Send Message as JSON',
+                          'value': self.config['as_json'],
+                          'name': 'mqtt_as_json',
+                          'description': 'Parse and send the subject and body as JSON, instead of as a raw string.',
                           'input_type': 'checkbox'
                           },
                          ]


### PR DESCRIPTION
## Description

(re-open of #1424)

This is a series of changes to improve the machine readability of notifications sent via MQTT. In particular, being able to send to multiple topics based on any parameter (i.e. I plan to include the {player_id} in the topic so that if I want to do automations for what's happening in a particular room, I only have to subscribe to that topic), and being able to either send bare
text not wrapped in JSON for simpler handling at the recipient OR being able to build a full JSON object with proper escaping to bundle a lot of information in a single notification.

### Issues Fixed or Closed

Fixes https://github.com/Tautulli/Tautulli/issues/1415 and https://github.com/Tautulli/Tautulli/issues/1416.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
