### PR TITLE
backports.zoneinfo environment marker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ apscheduler==3.9.1.post1
 arrow==1.2.3
 backports.csv==1.0.7
 backports.functools-lru-cache==1.6.4
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 beautifulsoup4==4.11.1
 bleach==5.0.1
 certifi==2022.9.24


### PR DESCRIPTION
## Description

https://github.com/pganssle/zoneinfo#installation-and-depending-on-this-library notes:
> Support for `backports.zoneinfo` in Python 3.9+ is currently minimal, since it is expected that you would use the standard library `zoneinfo` module instead.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
