### PR TITLE
Add session_key to LunaSea notifier payload

### DIFF
--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -2175,6 +2175,7 @@ class LUNASEA(Notifier):
                 'player': pretty_metadata.parameters.get('player'),
                 'title': pretty_metadata.get_title(),
                 'poster_url': pretty_metadata.get_poster_url(),
+                'session_key': pretty_metadata.parameters.get('session_key'),
                 'session_id': pretty_metadata.parameters.get('session_id'),
                 'user_streams': pretty_metadata.parameters.get('user_streams'),
                 'remote_access_reason': pretty_metadata.parameters.get('remote_access_reason'),


### PR DESCRIPTION
## Description

After a small discussion in the Discord, with some types of activity sessions no `session_id` is available so I am shifting LunaSea to use `session_key`s instead. This adds `session_key` to the notification payload for the LunaSea agent.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
