### PR TITLE
Update versionCheck to cast commit_hash to string

### DIFF
--- a/plexpy/versioncheck.py
+++ b/plexpy/versioncheck.py
@@ -101,7 +101,7 @@ def get_version():
         else:
             cur_commit_hash = str(output)
 
-        if not re.match('^[a-z0-9]+$', cur_commit_hash):
+        if not re.match('^[a-z0-9]+$', str(cur_commit_hash)):
             logger.error('Output does not look like a hash, not using it.')
             cur_commit_hash = None
 


### PR DESCRIPTION
## Description

After the most recent v2.11.0 update, Tautulli would not start until I made this change to the codebase.

### Issues Fixed or Closed

```bash
root@Tautulli:~ # python /usr/local/share/Tautulli/Tautulli.py
2022-12-22 16:29:18 - INFO :: MainThread : Starting Tautulli v2.11.0
2022-12-22 16:29:18 - INFO :: MainThread : FreeBSD 12.2-RELEASE-p11 (FreeBSD 12.2-RELEASE-p11 75566f060d4(HEAD) TRUENAS - FreeBSD 12.2)
2022-12-22 16:29:18 - INFO :: MainThread : local (UTC-0800)
2022-12-22 16:29:18 - INFO :: MainThread : Python 3.7.16 (default, Dec 10 2022, 18:47:41) [Clang 10.0.1 (gi********t@********:llvm/llvm-project.git llvmorg-10.0.1-0-gef32c611a
2022-12-22 16:29:18 - INFO :: MainThread : Program Dir: /usr/local/share/Tautulli
2022-12-22 16:29:18 - INFO :: MainThread : Config File: /usr/local/share/Tautulli/config.ini
2022-12-22 16:29:18 - INFO :: MainThread : Database File: /usr/local/share/Tautulli/tautulli.db
2022-12-22 16:29:18 - INFO :: MainThread : Checking if the database upgrades are required...
2022-12-22 16:29:18 - INFO :: MainThread : Checking if configuration upgrades are required...
2022-12-22 16:29:18 - DEBUG :: MainThread : Trying to execute: "git rev-parse HEAD" with shell in /usr/local/share/Tautulli
2022-12-22 16:29:18 - DEBUG :: MainThread : Git output: /bin/sh: git: not found
2022-12-22 16:29:18 - DEBUG :: MainThread : Unable to find git with command git rev-parse HEAD
2022-12-22 16:29:18 - ERROR :: MainThread : Could not find latest installed version.
2022-12-22 16:29:18 - ERROR :: MainThread : Uncaught exception: Traceback (most recent call last):
  File "/usr/local/share/Tautulli/Tautulli.py", line 324, in <module>
    main()
  File "/usr/local/share/Tautulli/Tautulli.py", line 244, in main
    plexpy.initialize(config_file)
  File "/usr/local/share/Tautulli/plexpy/__init__.py", line 322, in initialize
    CURRENT_VERSION, CONFIG.GIT_REMOTE, CONFIG.GIT_BRANCH = versioncheck.get_version()
  File "/usr/local/share/Tautulli/plexpy/versioncheck.py", line 104, in get_version
    if not re.match('^[a-z0-9]+$', cur_commit_hash):
  File "/usr/local/lib/python3.7/re.py", line 175, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
