### PR TITLE
edition detail field for movie info

### DIFF
--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -391,16 +391,16 @@ DOCUMENTATION :: END
                                 Runtime <strong> <span id="runtime">${data['duration']}</span></strong>
                                 % endif
                             </div>
-                            <div class="summary-content-details-tag">
-                                % if data['content_rating']:
-                                Rated <strong> ${data['content_rating']} </strong>
-                                % endif
-                            </div>
                             % if data['edition_title']:
                             <div class="summary-content-details-tag">
                                 Edition <strong> ${data['edition_title']} </strong>
                             </div>
                             % endif
+                            <div class="summary-content-details-tag">
+                                % if data['content_rating']:
+                                Rated <strong> ${data['content_rating']} </strong>
+                                % endif
+                            </div>
                             <div class="summary-content-details-tag" id="channel-icon">
                                 % if media_info['channel_identifier']:
                                 Channel <strong> <span class="thumb-tooltip" data-toggle="popover" data-img="${media_info['channel_thumb']}" data-height="40" data-width="40">${media_info['channel_call_sign']} ${media_info['channel_identifier']}</span> </strong>

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -14,6 +14,7 @@ rating_key              Returns the unique identifier for the media item.
 media_type              Returns the type of media. Either 'movie', 'show', 'season', 'episode', 'artist', 'album', or 'track'.
 art                     Returns the location of the item's artwork
 title                   Returns the name of the movie, show, episode, artist, album, or track.
+edition_title            Returns the edition title of a movie.
 duration                Returns the standard runtime of the media.
 content_rating          Returns the age rating for the media.
 summary                 Returns a brief description of the media plot.
@@ -395,6 +396,11 @@ DOCUMENTATION :: END
                                 Rated <strong> ${data['content_rating']} </strong>
                                 % endif
                             </div>
+                            % if data['edition_title']:
+                            <div class="summary-content-details-tag">
+                                Edition <strong> ${data['edition_title']} </strong>
+                            </div>
+                            % endif
                             <div class="summary-content-details-tag" id="channel-icon">
                                 % if media_info['channel_identifier']:
                                 Channel <strong> <span class="thumb-tooltip" data-toggle="popover" data-img="${media_info['channel_thumb']}" data-height="40" data-width="40">${media_info['channel_call_sign']} ${media_info['channel_identifier']}</span> </strong>


### PR DESCRIPTION
## Description

This PR adds the edition as a content detail field for a movie info if the movie has a edition specified else the field will not be displayed.

### Screenshot
With edition defined:
![image](https://user-images.githubusercontent.com/12448284/210300683-26fc73f3-02ee-4a3e-8656-a1866f54ee15.png)
Without edition defined:
![image](https://user-images.githubusercontent.com/12448284/210300950-a46d056c-90a0-4f55-8894-afe2f39c8a90.png)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
