### PR TITLE
Filter history by local and remote plays

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -2427,6 +2427,18 @@ a .library-user-instance-box:hover {
 .home-padded-header .button-bar {
     float: left;
 }
+#history-option-container {
+    float: right;
+    background-color: #333;
+    padding: 1rem;
+    border-radius: 0.6rem;
+}
+.history-option-bar {
+    margin: 0.2rem;
+}
+.history-option-button-group {
+    display: table-cell;
+}
 .home-platforms {
 }
 .home-platforms ul,

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -16,7 +16,7 @@
     </div>
     % endif
     <div class='table-card-header'>
-        <div class="header-bar">
+        <div class="header-bar" style="margin-top: 2.4rem;">
             <span><i class="fa fa-history"></i> History</span>
         </div>
         <div id="history-option-container" class="container">

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -19,65 +19,71 @@
         <div class="header-bar">
             <span><i class="fa fa-history"></i> History</span>
         </div>
-        <div class="button-bar">
-            % if _session['user_group'] == 'admin':
-            <div class="alert alert-danger alert-edit" role="alert" id="row-edit-mode-alert"><i class="fa fa-exclamation-triangle"></i>&nbsp</div>
-            <div class="btn-group">
-                <button class="btn btn-danger btn-edit" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
-                    <i class="fa fa-trash-o"></i> Delete mode
-                </button>
+        <div id="history-option-container" class="container">
+            <div class="button-bar history-option-bar" style="float: left;">
+                % if _session['user_group'] == 'admin':
+                <div class="alert alert-danger alert-edit" role="alert" id="row-edit-mode-alert"><i class="fa fa-exclamation-triangle"></i>&nbsp</div>
+                <div class="btn-group">
+                    <button class="btn btn-danger btn-edit" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
+                        <i class="fa fa-trash-o"></i> Delete mode
+                    </button>
+                </div>
+                % endif
+                % if _session['user_group'] == 'admin':
+                <div class="btn-group" id="user-selection">
+                    <label>
+                        <select name="history-user" id="history-user" class="btn" style="color: inherit;">
+                            <option value="">All Users</option>
+                            <option disabled>&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</option>
+                        </select>
+                    </label>
+                </div>
+                % endif
             </div>
-            % endif
-            % if _session['user_group'] == 'admin':
-            <div class="btn-group" id="user-selection">
-                <label>
-                    <select name="history-user" id="history-user" class="btn" style="color: inherit;">
-                        <option value="">All Users</option>
-                        <option disabled>&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</option>
-                    </select>
-                </label>
+            <div class="button-bar history-option-bar">         
+                <div class="btn-group">
+                    <button class="btn btn-dark refresh-history-button" id="refresh-history-list"><i class="fa fa-refresh"></i> Refresh history</button>
+                </div>
+                <div class="btn-group colvis-button-bar"></div>
             </div>
-            % endif
-            <div class="btn-group" data-toggle="buttons" id="media_type-selection">
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="media_type-filter" id="history-media_type-movie" value="movie" autocomplete="off"><i class="fa fa-film"></i> Movies
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="media_type-filter" id="history-media_type-episode" value="episode" autocomplete="off"><i class="fa fa-television"></i> TV Shows
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="media_type-filter" id="history-media_type-track" value="track" autocomplete="off"><i class="fa fa-music"></i> Music
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="media_type-filter" id="history-media_type-live" value="live" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Live TV
-                </label>
+            <div class="button-bar history-option-bar">
+                <div class="btn-group-justified history-option-button-group" data-toggle="buttons" id="media_type-selection" style="padding-right: 0.5rem;">
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="media_type-filter" id="history-media_type-movie" value="movie" autocomplete="off"><i class="fa fa-film"></i> Movies
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="media_type-filter" id="history-media_type-episode" value="episode" autocomplete="off"><i class="fa fa-television"></i> TV Shows
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="media_type-filter" id="history-media_type-track" value="track" autocomplete="off"><i class="fa fa-music"></i> Music
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="media_type-filter" id="history-media_type-live" value="live" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Live TV
+                    </label>
+                </div>
+                <div class="btn-group-justified history-option-button-group" data-toggle="buttons" id="network_type-selection" style="padding-right: 0.5rem;">
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="network_type-filter" id="history-network_type-lan" value="lan" autocomplete="off"><i class="fa fa-server"></i> Local Play
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="network_type-filter" id="history-network_type-wan" value="wan" autocomplete="off"><i class="fa fa-globe"></i> Remote Play
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="network_type-filter" id="history-network_type-cellular" value="cellular" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Mobile Play
+                    </label>
+                </div>
+                <div class="btn-group-justified history-option-button-group" data-toggle="buttons" id="transcode_decision-selection">
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_play" value="direct play" autocomplete="off"><i class="fa fa-play-circle"></i> Direct Play
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-copy" value="copy" autocomplete="off"><i class="fa fa-stream"></i> Direct Stream
+                    </label>
+                    <label class="btn btn-dark btn-filter">
+                        <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-transcode" value="transcode" autocomplete="off"><i class="fa fa-server"></i> Transcode
+                    </label>
+                </div>  
             </div>
-            <div class="btn-group" data-toggle="buttons" id="network_type-selection">
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="network_type-filter" id="history-network_type-lan" value="lan" autocomplete="off"><i class="fa fa-server"></i> Local Play
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="network_type-filter" id="history-network_type-wan" value="wan" autocomplete="off"><i class="fa fa-globe"></i> Remote Play
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="network_type-filter" id="history-network_type-cellular" value="cellular" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Mobile Play
-                </label>
-            </div>
-            <div class="btn-group" data-toggle="buttons" id="transcode_decision-selection">
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_play" value="direct play" autocomplete="off"><i class="fa fa-play-circle"></i> Direct Play
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-copy" value="copy" autocomplete="off"><i class="fa fa-stream"></i> Direct Stream
-                </label>
-                <label class="btn btn-dark btn-filter">
-                    <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-transcode" value="transcode" autocomplete="off"><i class="fa fa-server"></i> Transcode
-                </label>
-            </div>
-            <div class="btn-group">
-                <button class="btn btn-dark refresh-history-button" id="refresh-history-list"><i class="fa fa-refresh"></i> Refresh history</button>
-            </div>
-            <div class="btn-group colvis-button-bar"></div>
         </div>
     </div>
     <div class="table-card-back">

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -52,6 +52,17 @@
                     <input type="checkbox" name="media_type-filter" id="history-media_type-live" value="live" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Live TV
                 </label>
             </div>
+            <div class="btn-group" data-toggle="buttons" id="network_type-selection">
+                <label class="btn btn-dark btn-filter">
+                    <input type="checkbox" name="network_type-filter" id="history-network_type-lan" value="lan" autocomplete="off"><i class="fa fa-server"></i> Local Play
+                </label>
+                <label class="btn btn-dark btn-filter">
+                    <input type="checkbox" name="network_type-filter" id="history-network_type-wan" value="wan" autocomplete="off"><i class="fa fa-globe"></i> Remote Play
+                </label>
+                <label class="btn btn-dark btn-filter">
+                    <input type="checkbox" name="network_type-filter" id="history-network_type-cellular" value="cellular" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Mobile Play
+                </label>
+            </div>
             <div class="btn-group" data-toggle="buttons" id="transcode_decision-selection">
                 <label class="btn btn-dark btn-filter">
                     <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_play" value="direct play" autocomplete="off"><i class="fa fa-play-circle"></i> Direct Play
@@ -145,7 +156,7 @@
             }
         });
 
-        function loadHistoryTable(media_type, transcode_decision, selected_user_id) {
+        function loadHistoryTable(media_type, network_type, transcode_decision, selected_user_id) {
             history_table_options.ajax = {
                 url: 'get_history',
                 type: 'POST',
@@ -153,6 +164,7 @@
                     return {
                         json_data: JSON.stringify(d),
                         media_type: media_type,
+                        network_type: network_type,
                         transcode_decision: transcode_decision,
                         user_id: selected_user_id
                     };
@@ -177,6 +189,15 @@
                 history_table.draw();
             });
 
+            $('#network_type-selection').on('change', function () {
+                $('#network_type-selection > label').removeClass('active');
+                var selected_filter = $('input[name=network_type-filter]:checked', '#network_type-selection');
+                $(selected_filter).closest('label').addClass('active');
+                network_type = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
+                setLocalStorage('history_network_type', network_type);
+                history_table.draw();
+            });
+
             $('#transcode_decision-selection').on('change', function () {
                 $('#transcode_decision-selection > label').removeClass('active');
                 var selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
@@ -192,23 +213,30 @@
             });
         }
 
-        var selected_user_id = "${_session['user_group']}" == "admin" ? null : "${_session['user_id']}";
+        let selected_user_id = "${_session['user_group']}" == "admin" ? null : "${_session['user_id']}";
 
-        var media_type = getLocalStorage('history_media_type', 'all');
+        let media_type = getLocalStorage('history_media_type', 'all');
         $.each(media_type.split(','), function (i, item) {
-            var history_media_type = $('#history-media_type-' + item);
+            let history_media_type = $('#history-media_type-' + item);
             history_media_type.prop('checked', true);
             history_media_type.closest('label').addClass('active');
         });
 
-        var transcode_decision = getLocalStorage('history_transcode_decision', 'all');
+        let network_type = getLocalStorage('history_network_type', 'all');
+        $.each(network_type.split(','), function (i, item) {
+            let history_network_type = $('#history-network_type-' + item);
+            history_network_type.prop('checked', true);
+            history_network_type.closest('label').addClass('active');
+        });
+
+        let transcode_decision = getLocalStorage('history_transcode_decision', 'all');
         $.each(transcode_decision.split(','), function (i, item) {
-            var history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
+            let history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
             history_transcode_decision.prop('checked', true);
             history_transcode_decision.closest('label').addClass('active');
         });
 
-        loadHistoryTable(media_type, transcode_decision, selected_user_id);
+        loadHistoryTable(media_type, network_type, transcode_decision, selected_user_id);
 
         % if _session['user_group'] == 'admin':
         $('#row-edit-mode').on('click', function() {

--- a/data/interfaces/default/history.html
+++ b/data/interfaces/default/history.html
@@ -182,7 +182,7 @@
 
             $('#media_type-selection').on('change', function () {
                 $('#media_type-selection > label').removeClass('active');
-                var selected_filter = $('input[name=media_type-filter]:checked', '#media_type-selection');
+                let selected_filter = $('input[name=media_type-filter]:checked', '#media_type-selection');
                 $(selected_filter).closest('label').addClass('active');
                 media_type = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
                 setLocalStorage('history_media_type', media_type);
@@ -191,7 +191,7 @@
 
             $('#network_type-selection').on('change', function () {
                 $('#network_type-selection > label').removeClass('active');
-                var selected_filter = $('input[name=network_type-filter]:checked', '#network_type-selection');
+                let selected_filter = $('input[name=network_type-filter]:checked', '#network_type-selection');
                 $(selected_filter).closest('label').addClass('active');
                 network_type = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
                 setLocalStorage('history_network_type', network_type);
@@ -200,7 +200,7 @@
 
             $('#transcode_decision-selection').on('change', function () {
                 $('#transcode_decision-selection > label').removeClass('active');
-                var selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
+                let selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
                 $(selected_filter).closest('label').addClass('active');
                 transcode_decision = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
                 setLocalStorage('history_transcode_decision', transcode_decision);
@@ -213,23 +213,23 @@
             });
         }
 
-        let selected_user_id = "${_session['user_group']}" == "admin" ? null : "${_session['user_id']}";
+        const selected_user_id = "${_session['user_group']}" == "admin" ? null : "${_session['user_id']}";
 
-        let media_type = getLocalStorage('history_media_type', 'all');
+        const media_type = getLocalStorage('history_media_type', 'all');
         $.each(media_type.split(','), function (i, item) {
             let history_media_type = $('#history-media_type-' + item);
             history_media_type.prop('checked', true);
             history_media_type.closest('label').addClass('active');
         });
 
-        let network_type = getLocalStorage('history_network_type', 'all');
+        const network_type = getLocalStorage('history_network_type', '');
         $.each(network_type.split(','), function (i, item) {
             let history_network_type = $('#history-network_type-' + item);
             history_network_type.prop('checked', true);
             history_network_type.closest('label').addClass('active');
         });
 
-        let transcode_decision = getLocalStorage('history_transcode_decision', 'all');
+        const transcode_decision = getLocalStorage('history_transcode_decision', 'all');
         $.each(transcode_decision.split(','), function (i, item) {
             let history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
             history_transcode_decision.prop('checked', true);

--- a/data/interfaces/default/library.html
+++ b/data/interfaces/default/library.html
@@ -216,6 +216,17 @@ DOCUMENTATION :: END
                                                 </button>
                                             </div>
                                             % endif
+                                            <div class="btn-group" data-toggle="buttons" id="network_type-selection">
+                                                <label class="btn btn-dark btn-filter">
+                                                    <input type="checkbox" name="network_type-filter" id="history-network_type-lan" value="lan" autocomplete="off"><i class="fa fa-server"></i> Local Play
+                                                </label>
+                                                <label class="btn btn-dark btn-filter">
+                                                    <input type="checkbox" name="network_type-filter" id="history-network_type-wan" value="wan" autocomplete="off"><i class="fa fa-globe"></i> Remote Play
+                                                </label>
+                                                <label class="btn btn-dark btn-filter">
+                                                    <input type="checkbox" name="network_type-filter" id="history-network_type-cellular" value="cellular" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Mobile Play
+                                                </label>
+                                            </div>
                                             <div class="btn-group" data-toggle="buttons" id="transcode_decision-selection">
                                                 <label class="btn btn-dark btn-filter">
                                                     <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_play" value="direct play" autocomplete="off"><i class="fa fa-play-circle"></i> Direct Play
@@ -567,7 +578,7 @@ DOCUMENTATION :: END
 
     $(".inactive-library-tooltip").tooltip();
 
-    function loadHistoryTable(transcode_decision) {
+    function loadHistoryTable(network_type, transcode_decision) {
         // Build watch history table
         history_table_options.ajax = {
             url: 'get_history',
@@ -577,6 +588,7 @@ DOCUMENTATION :: END
                     json_data: JSON.stringify( d ),
                     section_id: section_id,
                     user_id: "${history_user_id}",
+                    network_type: network_type,
                     transcode_decision: transcode_decision
                 };
             }
@@ -590,23 +602,37 @@ DOCUMENTATION :: END
 
         $('#transcode_decision-selection').on('change', function () {
             $('#transcode_decision-selection > label').removeClass('active');
-            var selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
+            let selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
             $(selected_filter).closest('label').addClass('active');
             transcode_decision = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
             setLocalStorage('library_' + section_id + 'history_transcode_decision', transcode_decision);
+            history_table.draw();
+        });
+
+        $('#network_type-selection').on('change', function () {
+            $('#network_type-selection > label').removeClass('active');
+            let selected_filter = $('input[name=network_type-filter]:checked', '#network_type-selection');
+            $(selected_filter).closest('label').addClass('active');
+            network_type = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
+            setLocalStorage('library_' + section_id + 'history_network_type', network_type);
             history_table.draw();
         });
     }
 
     $('#nav-tabs-history').on('shown.bs.tab', function() {
         if (typeof(history_table) === 'undefined') {
-            var transcode_decision = getLocalStorage('library_' + section_id + 'history_transcode_decision', 'all');
+            const transcode_decision = getLocalStorage('library_' + section_id + 'history_transcode_decision', 'all');
             $.each(transcode_decision.split(','), function (i, item) {
-                var history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
+                let history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
                 history_transcode_decision.prop('checked', true);
                 history_transcode_decision.closest('label').addClass('active');
             });
-
+            const network_type = getLocalStorage('library_' + section_id + 'history_network_type', 'all');
+            $.each(network_type.split(','), function (i, item) {
+                let history_network_type = $('#history-network_type-' + item);
+                history_network_type.prop('checked', true);
+                history_network_type.closest('label').addClass('active');
+            });
             loadHistoryTable(transcode_decision);
         }
     });

--- a/data/interfaces/default/library.html
+++ b/data/interfaces/default/library.html
@@ -627,13 +627,13 @@ DOCUMENTATION :: END
                 history_transcode_decision.prop('checked', true);
                 history_transcode_decision.closest('label').addClass('active');
             });
-            const network_type = getLocalStorage('library_' + section_id + 'history_network_type', 'all');
+            const network_type = getLocalStorage('library_' + section_id + 'history_network_type', '');
             $.each(network_type.split(','), function (i, item) {
                 let history_network_type = $('#history-network_type-' + item);
                 history_network_type.prop('checked', true);
                 history_network_type.closest('label').addClass('active');
             });
-            loadHistoryTable(transcode_decision);
+            loadHistoryTable(network_type, transcode_decision);
         }
     });
 

--- a/data/interfaces/default/user.html
+++ b/data/interfaces/default/user.html
@@ -151,50 +151,67 @@ DOCUMENTATION :: END
                             <div class="row">
                                 <div class="col-md-12">
                                     <div class='table-card-header'>
-                                        <div class="header-bar">
+                                        <div class="header-bar" style="margin-top: 2.4rem;">
                                             <span>
                                                 <i class="fa fa-history"></i> History for <strong>
                                                     <span class="set-username">${data['friendly_name']}</span>
                                                 </strong>
                                             </span>
                                         </div>
-                                        <div class="button-bar">
-                                            % if _session['user_group'] == 'admin':
-                                            <div class="btn-group">
-                                                <button class="btn btn-danger btn-edit" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
-                                                    <i class="fa fa-trash-o"></i> Delete mode
-                                                </button>
+                                        <div id="history-option-container" class="container">
+                                            <div class="button-bar history-option-bar" style="float: left;">
+                                                % if _session['user_group'] == 'admin':
+                                                <div class="btn-group">
+                                                    <button class="btn btn-danger btn-edit" data-toggle="button" aria-pressed="false" autocomplete="off" id="row-edit-mode">
+                                                        <i class="fa fa-trash-o"></i> Delete mode
+                                                    </button>
+                                                </div>
+                                                % endif
                                             </div>
-                                            % endif
-                                            <div class="btn-group" data-toggle="buttons" id="media_type-selection">
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="media_type-filter" id="history-media_type-movie" value="movie" autocomplete="off"><i class="fa fa-film"></i> Movies
-                                                </label>
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="media_type-filter" id="history-media_type-episode" value="episode" autocomplete="off"><i class="fa fa-television"></i> TV Shows
-                                                </label>
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="media_type-filter" id="history-media_type-track" value="track" autocomplete="off"><i class="fa fa-music"></i> Music
-                                                </label>
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="media_type-filter" id="history-media_type-live" value="live" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Live TV
-                                                </label>
+                                            <div class="button-bar history-option-bar">         
+                                                <div class="btn-group">
+                                                    <button class="btn btn-dark refresh-history-button" id="refresh-history-list"><i class="fa fa-refresh"></i> Refresh history</button>
+                                                </div>
+                                                <div class="btn-group colvis-button-bar"></div>
                                             </div>
-                                            <div class="btn-group" data-toggle="buttons" id="transcode_decision-selection">
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_play" value="direct play" autocomplete="off"><i class="fa fa-play-circle"></i> Direct Play
-                                                </label>
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_stream" value="copy" autocomplete="off"><i class="fa fa-stream"></i> Direct Stream
-                                                </label>
-                                                <label class="btn btn-dark btn-filter">
-                                                    <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-transcode" value="transcode" autocomplete="off"><i class="fa fa-server"></i> Transcode
-                                                </label>
+                                            <div class="button-bar history-option-bar">
+                                                <div class="btn-group-justified history-option-button-group" data-toggle="buttons" id="media_type-selection" style="padding-right: 0.5rem;">
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="media_type-filter" id="history-media_type-movie" value="movie" autocomplete="off"><i class="fa fa-film"></i> Movies
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="media_type-filter" id="history-media_type-episode" value="episode" autocomplete="off"><i class="fa fa-television"></i> TV Shows
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="media_type-filter" id="history-media_type-track" value="track" autocomplete="off"><i class="fa fa-music"></i> Music
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="media_type-filter" id="history-media_type-live" value="live" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Live TV
+                                                    </label>
+                                                </div>
+                                                <div class="btn-group-justified history-option-button-group" data-toggle="buttons" id="network_type-selection" style="padding-right: 0.5rem;">
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="network_type-filter" id="history-network_type-lan" value="lan" autocomplete="off"><i class="fa fa-server"></i> Local Play
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="network_type-filter" id="history-network_type-wan" value="wan" autocomplete="off"><i class="fa fa-globe"></i> Remote Play
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="network_type-filter" id="history-network_type-cellular" value="cellular" autocomplete="off"><i class="fa fa-broadcast-tower"></i> Mobile Play
+                                                    </label>
+                                                </div>
+                                                <div class="btn-group-justified history-option-button-group" data-toggle="buttons" id="transcode_decision-selection">
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-direct_play" value="direct play" autocomplete="off"><i class="fa fa-play-circle"></i> Direct Play
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-copy" value="copy" autocomplete="off"><i class="fa fa-stream"></i> Direct Stream
+                                                    </label>
+                                                    <label class="btn btn-dark btn-filter">
+                                                        <input type="checkbox" name="transcode_decision-filter" id="history-transcode_decision-transcode" value="transcode" autocomplete="off"><i class="fa fa-server"></i> Transcode
+                                                    </label>
+                                                </div>  
                                             </div>
-                                            <div class="btn-group">
-                                                <button class="btn btn-dark refresh-history-button" id="refresh-history-list"><i class="fa fa-refresh"></i> Refresh history</button>
-                                            </div>
-                                            <div class="btn-group colvis-button-bar" id="button-bar-history"></div>
                                         </div>
                                     </div>
                                     <div class="table-card-back">
@@ -532,7 +549,7 @@ DOCUMENTATION :: END
 
     $(".inactive-user-tooltip").tooltip();
 
-    function loadHistoryTable(media_type, transcode_decision) {
+    function loadHistoryTable(media_type, network_type, transcode_decision) {
         // Build watch history table
         history_table_options.ajax = {
             url: 'get_history',
@@ -542,6 +559,7 @@ DOCUMENTATION :: END
                     json_data: JSON.stringify( d ),
                     user_id: user_id,
                     media_type: media_type,
+                    network_type: network_type,
                     transcode_decision: transcode_decision
                 };
             }
@@ -556,16 +574,25 @@ DOCUMENTATION :: END
 
         $('#media_type-selection').on('change', function () {
             $('#media_type-selection > label').removeClass('active');
-            var selected_filter = $('input[name=media_type-filter]:checked', '#media_type-selection');
+            let selected_filter = $('input[name=media_type-filter]:checked', '#media_type-selection');
             $(selected_filter).closest('label').addClass('active');
             media_type = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
             setLocalStorage('user_' + user_id + '-history_media_type', media_type);
             history_table.draw();
         });
 
+        $('#network_type-selection').on('change', function () {
+            $('#network_type-selection > label').removeClass('active');
+            let selected_filter = $('input[name=network_type-filter]:checked', '#network_type-selection');
+            $(selected_filter).closest('label').addClass('active');
+            network_type = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
+            setLocalStorage('user_' + user_id + 'history_network_type', network_type);
+            history_table.draw();
+        });
+
         $('#transcode_decision-selection').on('change', function () {
             $('#transcode_decision-selection > label').removeClass('active');
-            var selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
+            let selected_filter = $('input[name=transcode_decision-filter]:checked', '#transcode_decision-selection');
             $(selected_filter).closest('label').addClass('active');
             transcode_decision = $(selected_filter).map(function () { return $(this).val(); }).get().join(',');
             setLocalStorage('user_' + user_id + 'history_transcode_decision', transcode_decision);
@@ -575,21 +602,28 @@ DOCUMENTATION :: END
 
     $('#nav-tabs-history').on('shown.bs.tab', function() {
         if (typeof(history_table) === 'undefined') {
-            var media_type = getLocalStorage('user_' + user_id + '-history_media_type', 'all');
+            const media_type = getLocalStorage('user_' + user_id + '-history_media_type', 'all');
             $.each(media_type.split(','), function (i, item) {
-                var history_media_type = $('#history-media_type-' + item);
+                let history_media_type = $('#history-media_type-' + item);
                 history_media_type.prop('checked', true);
                 history_media_type.closest('label').addClass('active');
             });
 
-            var transcode_decision = getLocalStorage('user_' + user_id + 'history_transcode_decision', 'all');
+            const network_type = getLocalStorage('user_' + user_id + 'history_network_type', '');
+            $.each(network_type.split(','), function (i, item) {
+                let history_network_type = $('#history-network_type-' + item);
+                history_network_type.prop('checked', true);
+                history_network_type.closest('label').addClass('active');
+            });
+
+            const transcode_decision = getLocalStorage('user_' + user_id + 'history_transcode_decision', 'all');
             $.each(transcode_decision.split(','), function (i, item) {
-                var history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
+                let history_transcode_decision = $('#history-transcode_decision-' + item.replace(' ', '_'));
                 history_transcode_decision.prop('checked', true);
                 history_transcode_decision.closest('label').addClass('active');
             });
 
-            loadHistoryTable(media_type, transcode_decision);
+            loadHistoryTable(media_type, network_type, transcode_decision);
         }
     });
 

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -1898,6 +1898,7 @@ class WebInterface(object):
                 after (str):                    History after and including the date, "YYYY-MM-DD"
                 section_id (int):               2
                 media_type (str):               "movie", "episode", "track", "live"
+                network_type (str):             "lan", "wan", "cellular"
                 transcode_decision (str):       "direct play", "copy", "transcode",
                 guid (str):                     Plex guid for an item, e.g. "com.plexapp.agents.thetvdb://121361/6/1"
                 order_column (str):             "date", "friendly_name", "ip_address", "platform", "player",
@@ -2029,6 +2030,10 @@ class WebInterface(object):
             media_type = helpers.split_strip(kwargs.get('media_type', ''))
             if media_type and 'all' not in media_type:
                 custom_where.append(['media_type_live', media_type])
+        if 'network_type' in kwargs:
+            network_type = helpers.split_strip(kwargs.get('network_type', ''))
+            if network_type:
+                custom_where.append(['location', network_type])
         if 'transcode_decision' in kwargs:
             transcode_decision = helpers.split_strip(kwargs.get('transcode_decision', ''))
             if transcode_decision and 'all' not in transcode_decision:


### PR DESCRIPTION
## Description

This PR aims to implement feature request #1813 by adding a filter for the history table to filter on elements played in the local network (lan), played remote (wan) or mobile (cellular).

The settings/filter bar has partly been reworked to account for the space needed by the new buttons. With this re-arrangement additional filters, selections or buttons can be integrated in the yet free space.

Components:
- [x] History
- [x] Library History
- [x] User History

Open points:
- [ ] CSS optimization
- [x] Response Behaviour Check
- [ ] Font Awesome Update?

### Screenshot

**History**
![image](https://user-images.githubusercontent.com/12448284/211154457-3c5e5714-ff7d-4640-8114-168f43ab0af7.png)

**Library History**
![image](https://user-images.githubusercontent.com/12448284/211154513-8b13f89b-5d22-41b9-8adf-d8da954b1f90.png)


**User History**
![image](https://user-images.githubusercontent.com/12448284/211154523-033da0ac-70fc-467d-b5e2-2dedb4847d18.png)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
