### PR TITLE
watch time & user stats for collections

### DIFF
--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -931,7 +931,10 @@ DOCUMENTATION :: END
     $.ajax({
         url: 'item_watch_time_stats',
         async: true,
-        data: { rating_key: "${data['rating_key']}" },
+        data: { 
+            rating_key: "${data['rating_key']}",
+            media_type: "${data['media_type']}"    
+        },
         complete: function(xhr, status) {
             $("#watch-time-stats").html(xhr.responseText);
         }

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -543,10 +543,7 @@ DOCUMENTATION :: END
                     </div>
                 </div>
                 % endif
-                <%
-                    collection_valid = data['media_type'] == 'collection' and data['sub_media_type'] in ('movie', 'show', 'artist')
-                %>
-                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track') or collection_valid:
+                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
                 <div class="col-md-12">
                     <div class="table-card-header">
                         <div class="header-bar">
@@ -854,7 +851,6 @@ DOCUMENTATION :: END
 <%
     data = defaultdict(None, **metadata)
     history_user_id = '' if _session['user_group'] == 'admin' else _session['user_id']
-    collection_valid = data['media_type'] == 'collection' and data['sub_media_type'] in ('movie', 'show', 'artist')
 %>
 <script src="${http_root}js/tables/history_table.js${cache_param}"></script>
 <script src="${http_root}js/tables/export_table.js${cache_param}"></script>
@@ -930,7 +926,7 @@ DOCUMENTATION :: END
     });
 </script>
 % endif
-% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track') or "${collection_valid}":
+% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
 <script>
     // Populate watch time stats
     $.ajax({

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -12,6 +12,7 @@ data :: Usable parameters (if not applicable for media type, blank value will be
 == Global keys ==
 rating_key              Returns the unique identifier for the media item.
 media_type              Returns the type of media. Either 'movie', 'show', 'season', 'episode', 'artist', 'album', or 'track'.
+sub_media_type          Returns the subtype of media. Either 'movie', 'show', 'season', 'episode', 'artist', 'album', or 'track'.
 art                     Returns the location of the item's artwork
 title                   Returns the name of the movie, show, episode, artist, album, or track.
 duration                Returns the standard runtime of the media.
@@ -542,7 +543,10 @@ DOCUMENTATION :: END
                     </div>
                 </div>
                 % endif
-                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
+                <%
+                    collection_valid = data['media_type'] == 'collection' and data['sub_media_type'] in ('movie', 'show', 'artist')
+                %>
+                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track') or collection_valid:
                 <div class="col-md-12">
                     <div class="table-card-header">
                         <div class="header-bar">
@@ -850,6 +854,7 @@ DOCUMENTATION :: END
 <%
     data = defaultdict(None, **metadata)
     history_user_id = '' if _session['user_group'] == 'admin' else _session['user_id']
+    collection_valid = data['media_type'] == 'collection' and data['sub_media_type'] in ('movie', 'show', 'artist')
 %>
 <script src="${http_root}js/tables/history_table.js${cache_param}"></script>
 <script src="${http_root}js/tables/export_table.js${cache_param}"></script>
@@ -925,7 +930,7 @@ DOCUMENTATION :: END
     });
 </script>
 % endif
-% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
+% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track') or "${collection_valid}":
 <script>
     // Populate watch time stats
     $.ajax({

--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -542,7 +542,7 @@ DOCUMENTATION :: END
                     </div>
                 </div>
                 % endif
-                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track'):
+                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
                 <div class="col-md-12">
                     <div class="table-card-header">
                         <div class="header-bar">
@@ -925,7 +925,7 @@ DOCUMENTATION :: END
     });
 </script>
 % endif
-% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track'):
+% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
 <script>
     // Populate watch time stats
     $.ajax({
@@ -940,7 +940,10 @@ DOCUMENTATION :: END
     $.ajax({
         url: 'item_user_stats',
         async: true,
-        data: { rating_key: "${data['rating_key']}" },
+        data: { 
+            rating_key: "${data['rating_key']}",
+            media_type: "${data['media_type']}"    
+        },
         complete: function(xhr, status) {
             $("#user-stats").html(xhr.responseText);
         }

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1156,17 +1156,16 @@ class DataFactory(object):
 
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
-        _rating_keys = []
+        rating_keys = []
         if media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key)
 
             for child in result['children_list']:
-                _rating_keys.append(child['rating_key'])
+                rating_keys.append(child['rating_key'])
         else:
-            _rating_keys.append(rating_key)
+            rating_keys.append(rating_key)
 
-        rating_keys = ','.join(_rating_keys)
         rating_keys_arg = ','.join(['?'] * len(rating_keys))
 
         for days in query_days:
@@ -1180,13 +1179,14 @@ class DataFactory(object):
                                 'COUNT(DISTINCT %s) AS total_plays, section_id ' \
                                 'FROM session_history ' \
                                 'JOIN session_history_metadata ON session_history_metadata.id = session_history.id ' \
-                                'WHERE stopped >= ? ' \
+                                'WHERE stopped >= %s ' \
                                 'AND (session_history.grandparent_rating_key IN (%s) ' \
                                 'OR session_history.parent_rating_key IN (%s) ' \
                                 'OR session_history.rating_key IN (%s))' % (
-                                    group_by, rating_keys_arg, rating_keys_arg, rating_keys_arg
+                                    group_by, timestamp_query, rating_keys_arg, rating_keys_arg, rating_keys_arg
                                 )
-                        result = monitor_db.select(query, args=[timestamp_query, rating_keys, rating_keys, rating_keys])
+                        
+                        result = monitor_db.select(query, args=rating_keys*3)
                     else:
                         result = []
                 else:
@@ -1201,7 +1201,8 @@ class DataFactory(object):
                                 'OR session_history.rating_key IN (%s))' % (
                                     group_by, rating_keys_arg, rating_keys_arg, rating_keys_arg
                                 )
-                        result = monitor_db.select(query, args=[rating_keys, rating_keys, rating_keys])
+                        
+                        result = monitor_db.select(query, args=rating_keys*3)
                     else:
                         result = []
             except Exception as e:
@@ -1242,17 +1243,16 @@ class DataFactory(object):
         
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
-        _rating_keys = []
+        rating_keys = []
         if media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key)
 
             for child in result['children_list']:
-                _rating_keys.append(child['rating_key'])
+                rating_keys.append(child['rating_key'])
         else:
-            _rating_keys.append(rating_key)
+            rating_keys.append(rating_key)
 
-        rating_keys = ','.join(_rating_keys)
         rating_keys_arg = ','.join(['?'] * len(rating_keys))
 
         try:
@@ -1273,7 +1273,8 @@ class DataFactory(object):
                         'ORDER BY total_plays DESC, total_time DESC' % (
                             group_by, rating_keys_arg, rating_keys_arg, rating_keys_arg
                         )
-                result = monitor_db.select(query, args=[rating_keys, rating_keys, rating_keys])
+
+                result = monitor_db.select(query, args=rating_keys*3)
             else:
                 result = []
         except Exception as e:

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1159,7 +1159,7 @@ class DataFactory(object):
         rating_keys = []
         if media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
-            result = pms_connect.get_item_children(rating_key=rating_key)
+            result = pms_connect.get_item_children(rating_key=rating_key, media_type=media_type)
 
             for child in result['children_list']:
                 rating_keys.append(child['rating_key'])
@@ -1179,14 +1179,14 @@ class DataFactory(object):
                                 'COUNT(DISTINCT %s) AS total_plays, section_id ' \
                                 'FROM session_history ' \
                                 'JOIN session_history_metadata ON session_history_metadata.id = session_history.id ' \
-                                'WHERE stopped >= %s ' \
+                                'WHERE stopped >= ? ' \
                                 'AND (session_history.grandparent_rating_key IN (%s) ' \
                                 'OR session_history.parent_rating_key IN (%s) ' \
                                 'OR session_history.rating_key IN (%s))' % (
-                                    group_by, timestamp_query, rating_keys_arg, rating_keys_arg, rating_keys_arg
+                                    group_by, rating_keys_arg, rating_keys_arg, rating_keys_arg
                                 )
                         
-                        result = monitor_db.select(query, args=rating_keys*3)
+                        result = monitor_db.select(query, args=[timestamp_query] + rating_keys * 3)
                     else:
                         result = []
                 else:
@@ -1202,7 +1202,7 @@ class DataFactory(object):
                                     group_by, rating_keys_arg, rating_keys_arg, rating_keys_arg
                                 )
                         
-                        result = monitor_db.select(query, args=rating_keys*3)
+                        result = monitor_db.select(query, args=rating_keys * 3)
                     else:
                         result = []
             except Exception as e:
@@ -1246,7 +1246,7 @@ class DataFactory(object):
         rating_keys = []
         if media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
-            result = pms_connect.get_item_children(rating_key=rating_key)
+            result = pms_connect.get_item_children(rating_key=rating_key, media_type=media_type)
 
             for child in result['children_list']:
                 rating_keys.append(child['rating_key'])
@@ -1274,7 +1274,7 @@ class DataFactory(object):
                             group_by, rating_keys_arg, rating_keys_arg, rating_keys_arg
                         )
 
-                result = monitor_db.select(query, args=rating_keys*3)
+                result = monitor_db.select(query, args=rating_keys * 3)
             else:
                 result = []
         except Exception as e:

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 # This file is part of Tautulli.
 #
@@ -1156,15 +1156,12 @@ class DataFactory(object):
 
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
-        rating_keys = []
         if media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key, media_type=media_type)
-
-            for child in result['children_list']:
-                rating_keys.append(child['rating_key'])
+            rating_keys = [child['rating_key'] for child in result['children_list']]
         else:
-            rating_keys.append(rating_key)
+            rating_keys = [rating_key]
 
         rating_keys_arg = ','.join(['?'] * len(rating_keys))
 
@@ -1243,15 +1240,12 @@ class DataFactory(object):
         
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
-        rating_keys = []
         if media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key, media_type=media_type)
-
-            for child in result['children_list']:
-                rating_keys.append(child['rating_key'])
+            rating_keys = [child['rating_key'] for child in result['children_list']]
         else:
-            rating_keys.append(rating_key)
+            rating_keys = [rating_key]
 
         rating_keys_arg = ','.join(['?'] * len(rating_keys))
 

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1157,7 +1157,7 @@ class DataFactory(object):
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
         _rating_keys = []
-        if media_type == 'collection':
+        if media_type and media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key)
 
@@ -1239,7 +1239,7 @@ class DataFactory(object):
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
         _rating_keys = []
-        if media_type == 'collection':
+        if media_type and media_type == 'collection':
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key)
 

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -4471,7 +4471,7 @@ class WebInterface(object):
                 rating_key (str):       Rating key of the item
 
             Optional parameters:
-                media_type(str):        Media type of the item (only required for a collection)
+                media_type (str):        Media type of the item (only required for a collection)
                 grouping (int):         0 or 1
                 query_days (str):       Comma separated days, e.g. "1,7,30,0"
 
@@ -4505,7 +4505,9 @@ class WebInterface(object):
 
         if rating_key:
             item_data = datafactory.DataFactory()
-            result = item_data.get_watch_time_stats(rating_key=rating_key, media_type=media_type, grouping=grouping,
+            result = item_data.get_watch_time_stats(rating_key=rating_key,
+                                                    media_type=media_type,
+                                                    grouping=grouping,
                                                     query_days=query_days)
             if result:
                 return result
@@ -4527,7 +4529,7 @@ class WebInterface(object):
                 rating_key (str):       Rating key of the item
 
             Optional parameters:
-                media_type(str):        Media type of the item (only required for a collection)
+                media_type (str):        Media type of the item (only required for a collection)
                 grouping (int):         0 or 1
 
             Returns:
@@ -4556,7 +4558,9 @@ class WebInterface(object):
 
         if rating_key:
             item_data = datafactory.DataFactory()
-            result = item_data.get_user_stats(rating_key=rating_key, media_type=media_type, grouping=grouping)
+            result = item_data.get_user_stats(rating_key=rating_key,
+                                              media_type=media_type,
+                                              grouping=grouping)
             if result:
                 return result
             else:

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -4431,10 +4431,10 @@ class WebInterface(object):
 
     @cherrypy.expose
     @requireAuth()
-    def item_watch_time_stats(self, rating_key=None, **kwargs):
+    def item_watch_time_stats(self, rating_key=None, media_type=None, **kwargs):
         if rating_key:
             item_data = datafactory.DataFactory()
-            result = item_data.get_watch_time_stats(rating_key=rating_key)
+            result = item_data.get_watch_time_stats(rating_key=rating_key, media_type=media_type)
         else:
             result = None
 

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -4446,10 +4446,10 @@ class WebInterface(object):
 
     @cherrypy.expose
     @requireAuth()
-    def item_user_stats(self, rating_key=None, **kwargs):
+    def item_user_stats(self, rating_key=None, media_type=None, **kwargs):
         if rating_key:
             item_data = datafactory.DataFactory()
-            result = item_data.get_user_stats(rating_key=rating_key)
+            result = item_data.get_user_stats(rating_key=rating_key, media_type=media_type)
         else:
             result = None
 

--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -4463,7 +4463,7 @@ class WebInterface(object):
     @cherrypy.tools.json_out()
     @requireAuth(member_of("admin"))
     @addtoapi()
-    def get_item_watch_time_stats(self, rating_key=None, grouping=None, query_days=None, **kwargs):
+    def get_item_watch_time_stats(self, rating_key=None, media_type=None, grouping=None, query_days=None, **kwargs):
         """  Get the watch time stats for the media item.
 
             ```
@@ -4471,6 +4471,7 @@ class WebInterface(object):
                 rating_key (str):       Rating key of the item
 
             Optional parameters:
+                media_type(str):        Media type of the item (only required for a collection)
                 grouping (int):         0 or 1
                 query_days (str):       Comma separated days, e.g. "1,7,30,0"
 
@@ -4504,7 +4505,7 @@ class WebInterface(object):
 
         if rating_key:
             item_data = datafactory.DataFactory()
-            result = item_data.get_watch_time_stats(rating_key=rating_key, grouping=grouping,
+            result = item_data.get_watch_time_stats(rating_key=rating_key, media_type=media_type, grouping=grouping,
                                                     query_days=query_days)
             if result:
                 return result
@@ -4518,7 +4519,7 @@ class WebInterface(object):
     @cherrypy.tools.json_out()
     @requireAuth(member_of("admin"))
     @addtoapi()
-    def get_item_user_stats(self, rating_key=None, grouping=None, **kwargs):
+    def get_item_user_stats(self, rating_key=None, media_type=None, grouping=None, **kwargs):
         """  Get the user stats for the media item.
 
             ```
@@ -4526,6 +4527,7 @@ class WebInterface(object):
                 rating_key (str):       Rating key of the item
 
             Optional parameters:
+                media_type(str):        Media type of the item (only required for a collection)
                 grouping (int):         0 or 1
 
             Returns:
@@ -4554,7 +4556,7 @@ class WebInterface(object):
 
         if rating_key:
             item_data = datafactory.DataFactory()
-            result = item_data.get_user_stats(rating_key=rating_key, grouping=grouping)
+            result = item_data.get_user_stats(rating_key=rating_key, media_type=media_type, grouping=grouping)
             if result:
                 return result
             else:


### PR DESCRIPTION
## Description
This PR adds the **watch time stats** and **user stats** to collections as it was planned in the original PR (https://github.com/Tautulli/Tautulli/pull/1471#issuecomment-885698176).

For a collection the plays and durations are summed up based on the stats of the individual collection items.

Tested for:
- [x] Movies 
- [x] Series
- [x] Artists

### Screenshot

![image](https://user-images.githubusercontent.com/12448284/215339765-7c178a5a-cb60-4d9b-b213-0ce03f73fecf.png)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
