### PR TITLE
Add missing artist entries for artist collections

### DIFF
--- a/data/interfaces/default/info_children_list.html
+++ b/data/interfaces/default/info_children_list.html
@@ -180,7 +180,7 @@ DOCUMENTATION :: END
                      <a href="${page('info', child['rating_key'])}" title="${child['title']}">${child['title']}</a>
                 </h3>
             </div>
-            % elif child['media_type'] == 'album':
+            % elif child['media_type'] == 'album' or child['media_type'] == 'artist':
             <a href="${page('info', child['rating_key'])}" title="${child['title']}">
                 <div class="item-children-poster">
                     <div class="item-children-poster-face cover-item" style="background-image: url(${page('pms_image_proxy', child['thumb'], child['rating_key'], 300, 300, fallback='cover')});"></div>

--- a/data/interfaces/default/info_children_list.html
+++ b/data/interfaces/default/info_children_list.html
@@ -180,7 +180,7 @@ DOCUMENTATION :: END
                      <a href="${page('info', child['rating_key'])}" title="${child['title']}">${child['title']}</a>
                 </h3>
             </div>
-            % elif child['media_type'] == 'album' or child['media_type'] == 'artist':
+            % elif child['media_type'] in ('album', 'artist'):
             <a href="${page('info', child['rating_key'])}" title="${child['title']}">
                 <div class="item-children-poster">
                     <div class="item-children-poster-face cover-item" style="background-image: url(${page('pms_image_proxy', child['thumb'], child['rating_key'], 300, 300, fallback='cover')});"></div>


### PR DESCRIPTION
## Description
This PR adds the individual artist of a artist collection to the collection overview similar to how its done for a album collection.

### Screenshot
**Before:**
![image](https://user-images.githubusercontent.com/12448284/219979384-46673daf-30d3-45e6-b097-32a82e0bb870.png)

**After:**
![image](https://user-images.githubusercontent.com/12448284/219979407-60461f85-2114-443d-bbc7-fa174a0c9f33.png)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
