### PR TITLE
watch time & user stats for playlists

### DIFF
--- a/data/interfaces/default/info.html
+++ b/data/interfaces/default/info.html
@@ -554,7 +554,7 @@ DOCUMENTATION :: END
                     </div>
                 </div>
                 % endif
-                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
+                % if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection', 'playlist'):
                 <div class="col-md-12">
                     <div class="table-card-header">
                         <div class="header-bar">
@@ -937,7 +937,7 @@ DOCUMENTATION :: END
     });
 </script>
 % endif
-% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection'):
+% if data['media_type'] in ('movie', 'show', 'season', 'episode', 'artist', 'album', 'track', 'collection', 'playlist'):
 <script>
     // Populate watch time stats
     $.ajax({

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -1210,7 +1210,7 @@ class DataFactory(object):
 
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
-        if media_type == 'collection':
+        if media_type in ('collection', 'playlist'):
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key, media_type=media_type)
             rating_keys = [child['rating_key'] for child in result['children_list']]
@@ -1294,7 +1294,7 @@ class DataFactory(object):
         
         group_by = 'session_history.reference_id' if grouping else 'session_history.id'
 
-        if media_type == 'collection':
+        if media_type in ('collection', 'playlist'):
             pms_connect = pmsconnect.PmsConnect()
             result = pms_connect.get_item_children(rating_key=rating_key, media_type=media_type)
             rating_keys = [child['rating_key'] for child in result['children_list']]


### PR DESCRIPTION
## Description
This PR adds the watch time stats and user stats to playlists similar to collections.

For a playlist the plays and durations are summed up based on the stats of the individual playlist items.

Tested for:

- [x] Movies
- [x] Series
- [x] Music

### Screenshot
![Screenshot 2023-02-27 215038](https://user-images.githubusercontent.com/12448284/221682665-3694194b-e773-4b3c-96c7-a0ba49096036.png)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
