### PR TITLE
Fix Plex bug where bandwidth is falsely reported as 10Gbps and quality as 0.064Mbps

### DIFF
--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -352,7 +352,7 @@ class WebInterface(object):
 
         if result:
             session = next((s for s in result['sessions'] if s['session_key'] == session_key), None)
-            return serve_template(template_name="current_activity_instance.html", session=session)
+            return serve_template(template_name="current_activity_instance.html", session=helpers.clean_plexapi_sessions(session))
         else:
             return serve_template(template_name="current_activity_instance.html", session=None)
 
@@ -6049,19 +6049,26 @@ class WebInterface(object):
                           'lan_bandwidth': 0,
                           'wan_bandwidth': 0}
 
+                cleaned_sessions = []
+
                 for s in result['sessions']:
-                    if s['transcode_decision'] == 'transcode':
+                    s_cleaned = helpers.clean_plexapi_sessions(s)
+                    cleaned_sessions.append(s_cleaned)
+
+                    if s_cleaned['transcode_decision'] == 'transcode':
                         counts['stream_count_transcode'] += 1
-                    elif s['transcode_decision'] == 'copy':
+                    elif s_cleaned['transcode_decision'] == 'copy':
                         counts['stream_count_direct_stream'] += 1
                     else:
                         counts['stream_count_direct_play'] += 1
 
-                    counts['total_bandwidth'] += helpers.cast_to_int(s['bandwidth'])
-                    if s['location'] == 'lan':
-                        counts['lan_bandwidth'] += helpers.cast_to_int(s['bandwidth'])
+                    counts['total_bandwidth'] += helpers.cast_to_int(s_cleaned['bandwidth'])
+                    if s_cleaned['location'] == 'lan':
+                        counts['lan_bandwidth'] += helpers.cast_to_int(s_cleaned['bandwidth'])
                     else:
-                        counts['wan_bandwidth'] += helpers.cast_to_int(s['bandwidth'])
+                        counts['wan_bandwidth'] += helpers.cast_to_int(s_cleaned['bandwidth'])
+                
+                result['sessions'] = cleaned_sessions
 
                 result.update(counts)
 


### PR DESCRIPTION
## Description
Plex falsely reports the bandwidth and quality of transcodes as 10Gbps and 0.064Mbps respectively, when using "Convert (Maximum)" on a web browser (it's very possible this happens on other devices, but I can't test).

![image](https://github.com/Tautulli/Tautulli/assets/79016507/c640438a-0030-42ab-b4e1-6f09fade54ed)

I added a helper function to detect and attempt to fix the bug using data from the video bitrate.

I multiplied the bitrate by 1.5 to get the bandwidth. It's not going to be perfectly accurate, and it never will be unless Plex fix the bug themselves, but I believe it's a good enough increase to account for spikes in bitrate during playback.

### Screenshot

Before:

![image](https://github.com/Tautulli/Tautulli/assets/79016507/d9e4d94e-250d-4c49-a7a1-b20ca372a98f)

After:

![image](https://github.com/Tautulli/Tautulli/assets/79016507/48172cee-03a1-4f68-bcdc-ce70c9b77c41)


### Issues Fixed or Closed
Couldn't find any from a quick look, but I could be wrong.

## Type of Change
Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
