### PR TITLE
Quater values for History Watch Status

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -1281,7 +1281,7 @@ a .dashboard-activity-metadata-user-thumb:hover {
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
     z-index: 1;
-   -webkit-border-radius: 50%;
+    -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
     border-radius: 350%;
     overflow: hidden;
@@ -2853,6 +2853,32 @@ a .home-platforms-list-cover-face:hover
     text-overflow: ellipsis;
     overflow: hidden;
     max-width: 350px;
+}
+.circle {
+    margin: 0.05rem;
+    display: inline-block;
+    width: 1.55rem;
+    height: 1.55rem;
+    border-radius: 50%;
+    border: 0.2rem solid white;
+}
+.circle-quarter {
+    background-image:
+    linear-gradient(00deg, #0e253f 50%, transparent 50%),
+    linear-gradient(90deg, #d1d1d1 50%, transparent 50%);
+}
+.circle-half {
+    background-image:
+    linear-gradient(-90deg, #0e253f 50%, transparent 50%),
+    linear-gradient(90deg, #d1d1d1 50%, transparent 50%);
+    }
+.circle-three-quarter {
+    background-image:
+    linear-gradient(180deg, transparent 50%, #d1d1d1 50%),
+    linear-gradient(90deg, #d1d1d1 50%, transparent 50%);
+}
+.circle-full {
+    background: #d1d1d1;
 }
 #graph-tabs {
     padding-bottom: 10px;

--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -2855,30 +2855,28 @@ a .home-platforms-list-cover-face:hover
     max-width: 350px;
 }
 .circle {
-    margin: 0.05rem;
-    display: inline-block;
     width: 1.55rem;
     height: 1.55rem;
     border-radius: 50%;
-    border: 0.2rem solid white;
+    border: 0.2rem solid #eeeeee;
 }
 .circle-quarter {
     background-image:
-    linear-gradient(00deg, #0e253f 50%, transparent 50%),
-    linear-gradient(270deg, #d1d1d1 50%, transparent 50%);
+    linear-gradient(00deg, #2b2b2b 50%, transparent 50%),
+    linear-gradient(270deg, #eeeeee 50%, transparent 50%);
 }
 .circle-half {
     background-image:
-    linear-gradient(90deg, #0e253f 50%, transparent 50%),
-    linear-gradient(-90deg, #d1d1d1 50%, transparent 50%);
+    linear-gradient(90deg, #2b2b2b 50%, transparent 50%),
+    linear-gradient(-90deg, #eeeeee 50%, transparent 50%);
     }
 .circle-three-quarter {
     background-image:
-    linear-gradient(180deg, transparent 50%, #d1d1d1 50%),
-    linear-gradient(-90deg, #d1d1d1 50%, transparent 50%);
+    linear-gradient(180deg, transparent 50%, #eeeeee 50%),
+    linear-gradient(-90deg, #eeeeee 50%, transparent 50%);
 }
 .circle-full {
-    background: #d1d1d1;
+    background: #eeeeee;
 }
 #graph-tabs {
     padding-bottom: 10px;

--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -338,20 +338,20 @@ object {
 }
 .btn-dark:focus,
 .btn-dark.focus {
-  color: #d7d7d7;
-  background-color: #3B3B3B;
+    color: #d7d7d7;
+    background-color: #3B3B3B;
 }
 .btn-dark:hover {
-  color: #eee;
-  background-color: #333;
-  border-color: #444;
+    color: #eee;
+    background-color: #333;
+    border-color: #444;
 }
 .btn-dark:active,
 .btn-dark.active,
 .open > .dropdown-toggle.btn-dark {
-  color: #eee;
-  background-color: #333;
-  border-color: #444;
+    color: #eee;
+    background-color: #333;
+    border-color: #444;
 }
 .btn-dark:active:hover,
 .btn-dark.active:hover,
@@ -362,13 +362,13 @@ object {
 .btn-dark:active.focus,
 .btn-dark.active.focus,
 .open > .dropdown-toggle.btn-dark.focus {
-  color: #eee;
-  background-color: #333;
+    color: #eee;
+    background-color: #333;
 }
 .btn-dark:active,
 .btn-dark.active,
 .open > .dropdown-toggle.btn-dark {
-  background-image: none;
+    background-image: none;
 }
 .btn-dark.disabled,
 .btn-dark[disabled],
@@ -388,8 +388,8 @@ fieldset[disabled] .btn-dark:active,
 .btn-dark.disabled.active,
 .btn-dark[disabled].active,
 fieldset[disabled] .btn-dark.active {
-  background-color: #333;
-  color: #aaa;
+    background-color: #333;
+    color: #aaa;
 }
 .btn-dark.inactive:hover {
     color: #d7d7d7;
@@ -398,30 +398,30 @@ fieldset[disabled] .btn-dark.active {
     cursor: default;
 }
 .btn-dark .badge {
-  color: #e5e5e5;
-  background-color: #3B3B3B;
+    color: #e5e5e5;
+    background-color: #3B3B3B;
 }
 .btn-bright {
-  color: #eee;
-  background-color: #cc7b19;
-  box-shadow: inset 0 1px 0 #e7993b;
+    color: #eee;
+    background-color: #cc7b19;
+    box-shadow: inset 0 1px 0 #e7993b;
 }
 .btn-bright:focus,
 .btn-bright.focus {
-  color: #eee;
-  background-color: #eb8600;
+    color: #eee;
+    background-color: #eb8600;
 }
 .btn-bright:hover {
-  color: #eee;
-  background-color: #e59029;
-  box-shadow: inset 0 1px 0 #ebac60;
+    color: #eee;
+    background-color: #e59029;
+    box-shadow: inset 0 1px 0 #ebac60;
 }
 .btn-bright:active,
 .btn-bright.active,
 .open > .dropdown-toggle.btn-bright {
-  color: #eee;
-  background-color: #cc7b19;
-  box-shadow: inset 0 1px 0 #e7993b;
+    color: #eee;
+    background-color: #cc7b19;
+    box-shadow: inset 0 1px 0 #e7993b;
 }
 .btn-bright:active:hover,
 .btn-bright.active:hover,
@@ -432,14 +432,14 @@ fieldset[disabled] .btn-dark.active {
 .btn-bright:active.focus,
 .btn-bright.active.focus,
 .open > .dropdown-toggle.btn-bright.focus {
-  color: #eee;
-  background-color: #cc7b19;
-  box-shadow: inset 0 1px 0 #e7993b;
+    color: #eee;
+    background-color: #cc7b19;
+    box-shadow: inset 0 1px 0 #e7993b;
 }
 .btn-bright:active,
 .btn-bright.active,
 .open > .dropdown-toggle.btn-bright {
-  background-image: none;
+    background-image: none;
 }
 .btn-bright.disabled,
 .btn-bright[disabled],
@@ -459,13 +459,13 @@ fieldset[disabled] .btn-bright:active,
 .btn-bright.disabled.active,
 .btn-bright[disabled].active,
 fieldset[disabled] .btn-bright.active {
-  background-color: #cc7b19;
-  border-color: #b56d16;
+    background-color: #cc7b19;
+    border-color: #b56d16;
 }
 .btn-bright .badge {
-  color: #eee;
-  background-color: #cc7b19;
-  box-shadow: inset 0 1px 0 #e7993b;
+    color: #eee;
+    background-color: #cc7b19;
+    box-shadow: inset 0 1px 0 #e7993b;
 }
 .btn-danger.btn-edit {
     color: #d7d7d7;
@@ -479,14 +479,14 @@ fieldset[disabled] .btn-bright.active {
     border-color: #ac2925;
 }
 .btn-danger.btn-edit.active {
-  color: #eee;
-  background-color: #c9302c;
-  border-color: #ac2925;
+    color: #eee;
+    background-color: #c9302c;
+    border-color: #ac2925;
 }
 .btn-danger.btn-edit.active:hover {
-  color: #eee;
-  background-color: #ac2925;
-  border-color: #761c19;
+    color: #eee;
+    background-color: #ac2925;
+    border-color: #761c19;
 }
 .btn-group select {
     margin-top: 0;
@@ -667,12 +667,12 @@ textarea.form-control:focus {
     white-space: nowrap;
     vertical-align: middle;
     -ms-touch-action: manipulation;
-      touch-action: manipulation;
+    touch-action: manipulation;
     cursor: pointer;
     -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
     background-image: none;
     background-color: #3B3B3B;
     color: #e5e5e5;
@@ -690,10 +690,10 @@ textarea.form-control:focus {
 }
 .btn-filter.active,
 .btn-filter.active.focus {
-  background-color: #b7800a !important;
+    background-color: #b7800a !important;
 }
 .btn-filter.active:hover {
-  background-color: #896007 !important;
+    background-color: #896007 !important;
 }
 .form-control-feedback {
     color: #E5A00D;
@@ -2203,8 +2203,8 @@ span.settings-warning {
     padding-left: 10px;
 }
 #menu_link_show_advanced_settings.active {
-  color: #eee;
-  background-color: #cc7b19;
+    color: #eee;
+    background-color: #cc7b19;
 }
 #configUpdate .form-group,
 #configUpdate .checkbox{
@@ -3016,8 +3016,8 @@ a .home-platforms-list-cover-face:hover
     border-left: 2px solid #444;
     border-top: 1px solid #2d2d2d;
     -webkit-transition: all 0.3s ease;
-      -o-transition: all 0.3s ease;
-      transition: all 0.3s ease;
+    -o-transition: all 0.3s ease;
+    transition: all 0.3s ease;
 }
 .stacked-configs > li > span:hover,
 .stacked-configs > li > span:focus {

--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -2869,8 +2869,8 @@ a .home-platforms-list-cover-face:hover
 }
 .circle-half {
     background-image:
-    linear-gradient(-90deg, #0e253f 50%, transparent 50%),
-    linear-gradient(90deg, #d1d1d1 50%, transparent 50%);
+    linear-gradient(90deg, #0e253f 50%, transparent 50%),
+    linear-gradient(-90deg, #d1d1d1 50%, transparent 50%);
     }
 .circle-three-quarter {
     background-image:

--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -2865,7 +2865,7 @@ a .home-platforms-list-cover-face:hover
 .circle-quarter {
     background-image:
     linear-gradient(00deg, #0e253f 50%, transparent 50%),
-    linear-gradient(90deg, #d1d1d1 50%, transparent 50%);
+    linear-gradient(270deg, #d1d1d1 50%, transparent 50%);
 }
 .circle-half {
     background-image:
@@ -2875,7 +2875,7 @@ a .home-platforms-list-cover-face:hover
 .circle-three-quarter {
     background-image:
     linear-gradient(180deg, transparent 50%, #d1d1d1 50%),
-    linear-gradient(90deg, #d1d1d1 50%, transparent 50%);
+    linear-gradient(-90deg, #d1d1d1 50%, transparent 50%);
 }
 .circle-full {
     background: #d1d1d1;

--- a/data/interfaces/default/js/tables/history_table.js
+++ b/data/interfaces/default/js/tables/history_table.js
@@ -263,13 +263,17 @@ history_table_options = {
             "targets": [12],
             "data": "watched_status",
             "createdCell": function (td, cellData, rowData, row, col) {
+                var circleValue = "";
                 if (cellData == 1) {
-                    $(td).html('<span class="watched-tooltip" data-toggle="tooltip" title="' + rowData['percent_complete'] + '%"><i class="fa fa-lg fa-circle"></i></span>');
+                    circleValue = " circle-full";
+                } else if (cellData == 0.75) {
+                    circleValue = " circle-three-quarter";
                 } else if (cellData == 0.5) {
-                    $(td).html('<span class="watched-tooltip" data-toggle="tooltip" title="' + rowData['percent_complete'] + '%"><i class="fa fa-lg fa-adjust fa-rotate-180"></i></span>');
-                } else {
-                    $(td).html('<span class="watched-tooltip" data-toggle="tooltip" title="' + rowData['percent_complete'] + '%"><i class="fa fa-lg fa-circle-o"></i></span>');
+                    circleValue = " circle-half";
+                } else if (cellData == 0.25) {
+                    circleValue = " circle-quarter";
                 }
+                $(td).html('<span class="watched-tooltip" data-toggle="tooltip" title="' + rowData['percent_complete'] + '%"><div class="circle' + circleValue + '" /></span>');
             },
             "searchable": false,
             "orderable": false,

--- a/plexpy/datafactory.py
+++ b/plexpy/datafactory.py
@@ -282,13 +282,19 @@ class DataFactory(object):
             if item['live']:
                 item['percent_complete'] = 100
 
+            base_watched_value = watched_percent[item['media_type']] / 4.0
+
             if helpers.check_watched(
                 item['media_type'], item['view_offset'], item['duration'],
                 item['marker_credits_first'], item['marker_credits_final']
             ):
                 watched_status = 1
-            elif item['percent_complete'] >= watched_percent[item['media_type']] / 2.0:
-                watched_status = 0.5
+            elif item['percent_complete'] >= base_watched_value * 3.0:
+                watched_status = 0.75
+            elif item['percent_complete'] >= base_watched_value * 2.0:
+                watched_status = 0.50
+            elif item['percent_complete'] >= base_watched_value:
+                watched_status = 0.25
             else:
                 watched_status = 0
 


### PR DESCRIPTION
## Description

Introduces quarter values to the watch status.

The existing calculation in the `datafactory` was extended to account for the new status options. The `history_table` was changed from using FontAwesome icons to a custom css class _(I took your example there as a basis)_.

### Screenshot
**Before**
![image](https://github.com/Tautulli/Tautulli/assets/12448284/0b0a6113-d115-4a86-b2ac-8855f507e6ed)

**After**
![image](https://github.com/Tautulli/Tautulli/assets/12448284/282f103f-582f-4260-8485-0670ca6e0dea)


Include screenshots if the changes are UI-related.

### Issues Fixed or Closed

- Implements #2156 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
