### PR TITLE
Add Mailgun Agent

### DIFF
--- a/data/interfaces/default/newsletter_config.html
+++ b/data/interfaces/default/newsletter_config.html
@@ -5,7 +5,7 @@
     from plexpy.helpers import anon_url, checked
 
     all_notifiers = sorted(notifiers.get_notifiers(), key=lambda k: (k['agent_label'].lower(), k['friendly_name'], k['id']))
-    email_notifiers = [n for n in all_notifiers if n['agent_name'] == 'email']
+    email_notifiers = [n for n in all_notifiers if n['agent_name'] == 'email' or n['agent_name'] == 'mailgun']
     email_notifiers = [{'id': 0, 'agent_label': 'New Email Configuration', 'friendly_name': ''}] + email_notifiers
     other_notifiers = [{'id': 0, 'agent_label': 'Select a Notification Agent', 'friendly_name': ''}] + all_notifiers
 %>


### PR DESCRIPTION
## Description

Adds a notification agent for Mailgun using the Mailgun API and allows using it for newsletters

Adds the ability to:
- Send to all email addresses in a Mailgun mailing list
- Enable open and click tracking
- Add tags to emails

### Screenshot

![image](https://github.com/Tautulli/Tautulli/assets/706048/3fe5e38a-809f-48e3-8a88-f8031273db79)
![image](https://github.com/Tautulli/Tautulli/assets/706048/dcd189e2-ed98-4b2c-a9b2-7a0c233eb37c)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
