### PR TITLE
Fix typo related to scroller, fix scrolling

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -927,6 +927,7 @@ a .users-poster-face:hover {
     -webkit-flex-grow: 1;
     flex-grow: 1;
     z-index: 1;
+    overflow: scroll;
 }
 .dashboard-activity-info-scroller.scrollbar-macosx > .scroll-element.scroll-y {
     left: 10px;

--- a/data/interfaces/default/current_activity_instance.html
+++ b/data/interfaces/default/current_activity_instance.html
@@ -148,7 +148,7 @@ DOCUMENTATION :: END
             </div>
             <div class="dashboard-activity-info-container">
                 <div class="dashboard-activity-info-scroller scrollbar-macosx">
-                    <div class="dashboard-activity-info scoller-content">
+                    <div class="dashboard-activity-info scroller-content">
                         <ul class="list-unstyled dashboard-activity-info-list">
                             <li class="dashboard-activity-info-item">
                                 <div class="sub-heading">Product</div>

--- a/data/interfaces/default/home_stats.html
+++ b/data/interfaces/default/home_stats.html
@@ -141,7 +141,7 @@ DOCUMENTATION :: END
                     % endif
                 </div>
                 <div class="dashboard-stats-info-scroller scrollbar-macosx">
-                    <div class="dashboard-stats-info scoller-content">
+                    <div class="dashboard-stats-info scroller-content">
                         <ul class="list-unstyled dashboard-stats-info-list">
                             % for row in top_stat['rows']:
                             <li class="dashboard-stats-info-item ${'expanded' if loop.index == 0 else ''}" data-stat_id="${stat_id}"

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -236,7 +236,7 @@
 
     function lockScroll(elem) {
         $(elem).each(function (i, instance)  {
-            var childHeight = $(instance).children('.scoller-content').height();
+            var childHeight = $(instance).children('.scroller-content').height();
             var height = $(instance).height();
             var scrollHeight = $(instance).get(0).scrollHeight;
 

--- a/data/interfaces/default/library_stats.html
+++ b/data/interfaces/default/library_stats.html
@@ -52,7 +52,7 @@ DOCUMENTATION :: END
                     <span class="dashboard-stats-stats-units">${' / '.join(u for u in headers[section_type][1] if u)}</span>
                 </div>
                 <div class="dashboard-stats-info-scroller scrollbar-macosx">
-                    <div class="dashboard-stats-info scoller-content">
+                    <div class="dashboard-stats-info scroller-content">
                         <ul class="list-unstyled dashboard-stats-info-list">
                             % for section in data[section_type]:
                             <li class="dashboard-stats-info-item ${'expanded' if loop.index == 0 else ''}" data-stat_id="${section_type}"


### PR DESCRIPTION
## Description

If this is the sort of behavior you’re interested in a now playing card, feel free to merge in!

- fixes #2221 by adding `overflow: scroll` to tautulli.css.
- fixes scroller-content typo related to area of fix

### Screenshot

<img width="552" alt="Screenshot 2024-06-04 at 6 57 38 PM" src="https://github.com/Tautulli/Tautulli/assets/435896/c428dd40-c1a5-402d-84df-572f0c4272cd">

### Issues Fixed or Closed

- Fixes #2221

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
