### PR TITLE
Removed deprecated getdefaultlocale (#2345)

### DIFF
--- a/Tautulli.py
+++ b/Tautulli.py
@@ -71,19 +71,29 @@ def main():
 
     try:
 
+        # Attempt to get the system's locale settings
         language_code, encoding = locale.getlocale()
+
+        # If encoding is not returned, get the encoding
         if not encoding:
             encoding = locale.getencoding()
 
-        # Special case for Windows where getlocale doesn't return correctly
+        # Special handling for Windows platform
         if sys.platform == 'win32':
-            # Get the kernel of the OS and the default UI Language to locate the language code in Windows
+            # Get the user's default UI language on Windows
             windll = ctypes.windll.kernel32
-            language_code = locale.windows_locale[windll.GetUserDefaultUILanguage()]
+            lang_id = windll.GetUserDefaultUILanguage()
+
+            # Map Windows language ID to locale identifier
+            language_code = locale.windows_locale.get(lang_id, '')
+
+            # Set encoding to Windows default encoding
             encoding = "cp1252"
 
+        # Assign values to application-specific variable
         plexpy.SYS_LANGUAGE = language_code
         plexpy.SYS_ENCODING = encoding
+
     except (locale.Error, IOError):
         pass
 

--- a/Tautulli.py
+++ b/Tautulli.py
@@ -70,7 +70,9 @@ def main():
 
     try:
         locale.setlocale(locale.LC_ALL, "")
-        plexpy.SYS_LANGUAGE, plexpy.SYS_ENCODING = locale.getdefaultlocale()
+        plexpy.SYS_LANGUAGE, plexpy.SYS_ENCODING = locale.getlocale()
+        if not plexpy.SYS_ENCODING:
+            plexpy.SYS_ENCODING = locale.getencoding()
     except (locale.Error, IOError):
         pass
 

--- a/Tautulli.py
+++ b/Tautulli.py
@@ -34,6 +34,7 @@ import shutil
 import time
 import threading
 import tzlocal
+import ctypes
 
 import plexpy
 from plexpy import common, config, database, helpers, logger, webstart
@@ -69,10 +70,20 @@ def main():
     plexpy.SYS_ENCODING = None
 
     try:
-        locale.setlocale(locale.LC_ALL, "")
-        plexpy.SYS_LANGUAGE, plexpy.SYS_ENCODING = locale.getlocale()
-        if not plexpy.SYS_ENCODING:
-            plexpy.SYS_ENCODING = locale.getencoding()
+
+        language_code, encoding = locale.getlocale()
+        if not encoding:
+            encoding = locale.getencoding()
+
+        # Special case for Windows where getlocale doesn't return correctly
+        if sys.platform == 'win32':
+            # Get the kernel of the OS and the default UI Language to locate the language code in Windows
+            windll = ctypes.windll.kernel32
+            language_code = locale.windows_locale[windll.GetUserDefaultUILanguage()]
+            encoding = "cp1252"
+
+        plexpy.SYS_LANGUAGE = language_code
+        plexpy.SYS_ENCODING = encoding
     except (locale.Error, IOError):
         pass
 

--- a/Tautulli.py
+++ b/Tautulli.py
@@ -76,13 +76,13 @@ def main():
 
         # If encoding is not returned, get the encoding
         if not encoding:
-            encoding = locale.getencoding()
+            encoding = locale.getpreferredencoding()
 
         # Special handling for Windows platform
         if sys.platform == 'win32':
-            # Get the user's default UI language on Windows
+            # Get the user's current language settings on Windows
             windll = ctypes.windll.kernel32
-            lang_id = windll.GetUserDefaultUILanguage()
+            lang_id = windll.GetUserDefaultLCID()
 
             # Map Windows language ID to locale identifier
             language_code = locale.windows_locale.get(lang_id, '')

--- a/Tautulli.py
+++ b/Tautulli.py
@@ -74,10 +74,6 @@ def main():
         # Attempt to get the system's locale settings
         language_code, encoding = locale.getlocale()
 
-        # If encoding is not returned, get the encoding
-        if not encoding:
-            encoding = locale.getpreferredencoding()
-
         # Special handling for Windows platform
         if sys.platform == 'win32':
             # Get the user's current language settings on Windows
@@ -87,8 +83,8 @@ def main():
             # Map Windows language ID to locale identifier
             language_code = locale.windows_locale.get(lang_id, '')
 
-            # Set encoding to Windows default encoding
-            encoding = "cp1252"
+        # Get the preferred encoding
+        encoding = locale.getpreferredencoding()
 
         # Assign values to application-specific variable
         plexpy.SYS_LANGUAGE = language_code


### PR DESCRIPTION
## Description

Tautulli.py used locale.getdefaultlocale() in line 73
```python
 plexpy.SYS_LANGUAGE, plexpy.SYS_ENCODING = locale.getdefaultlocale()
``` 
This method is deprecated.

```
DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead. plexpy.SYS_LANGUAGE, plexpy.SYS_ENCODING = locale.getdefaultlocale()
``` 

I changed the line with:
```python
 plexpy.SYS_LANGUAGE, plexpy.SYS_ENCODING = locale.getlocale()
 if not plexpy.SYS_ENCODING:
     plexpy.SYS_ENCODING = locale.getencoding()
``` 

### Issues Fixed or Closed

- Fixes #2345 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
