### PR TITLE
detect HDR transcodes via colorTrc attribute

### DIFF
--- a/plexpy/pmsconnect.py
+++ b/plexpy/pmsconnect.py
@@ -3386,10 +3386,10 @@ class PmsConnect(object):
     def get_dynamic_range(stream):
         extended_display_title = helpers.get_xml_attr(stream, 'extendedDisplayTitle')
         bit_depth = helpers.cast_to_int(helpers.get_xml_attr(stream, 'bitDepth'))
-        color_space = helpers.get_xml_attr(stream, 'colorSpace')
+        color_trc = helpers.get_xml_attr(stream, 'colorTrc')
         DOVI_profile = helpers.get_xml_attr(stream, 'DOVIProfile')
 
-        HDR = bool(bit_depth > 8 and 'bt2020' in color_space)
+        HDR = bool(bit_depth > 8 and (color_trc == 'smpte2084' or color_trc == 'arib-std-b67'))
         DV = bool(DOVI_profile)
 
         if not HDR and not DV:


### PR DESCRIPTION
## Description

Detect if HEVC transcodes result in an HDR or SDR video

### Screenshot

![image](https://github.com/user-attachments/assets/5dc3181e-3d9b-4982-9377-4a66c4572569)

### Issues Fixed or Closed

- Fixes #2412

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the docstring for new or existing methods
