### PR TITLE
Add hidden-by-default Total curve to the daily stream graph

### DIFF
--- a/data/interfaces/default/graphs.html
+++ b/data/interfaces/default/graphs.html
@@ -301,6 +301,10 @@
             return obj;
         }, {});
 
+        if (!("Total" in chart_visibility)) {
+            chart_visibility["Total"] = false;
+        }
+
         return data_series.map(function(s) {
             var obj = Object.assign({}, s);
             obj.visible = (chart_visibility[s.name] !== false);
@@ -327,7 +331,8 @@
             'Direct Play': '#E5A00D',
             'Direct Stream': '#FFFFFF',
             'Transcode': '#F06464',
-            'Max. Concurrent Streams': '#96C83C'
+            'Max. Concurrent Streams': '#96C83C',
+            'Total': '#F06464'
         };
         var series_colors = [];
         $.each(data_series, function(index, series) {

--- a/data/interfaces/default/graphs.html
+++ b/data/interfaces/default/graphs.html
@@ -332,7 +332,7 @@
             'Direct Stream': '#FFFFFF',
             'Transcode': '#F06464',
             'Max. Concurrent Streams': '#96C83C',
-            'Total': '#F06464'
+            'Total': '#96C83C'
         };
         var series_colors = [];
         $.each(data_series, function(index, series) {

--- a/plexpy/graphs.py
+++ b/plexpy/graphs.py
@@ -138,6 +138,12 @@ class Graphs(object):
         if libraries.has_library_type('live'):
             series_output.append(series_4_output)
 
+        if len(series_output) > 0:
+            series_total = [sum(x) for x in zip(*[x['data'] for x in series_output])]
+            series_total_output = {'name': 'Total',
+                                   'data': series_total}
+            series_output.append(series_total_output)
+
         output = {'categories': categories,
                   'series': series_output}
         return output


### PR DESCRIPTION
## Description

Adds a "Total" curve that is disabled by default, on the "Daily Play count by media type" graph. Most other graphs for which a total curve is relevant have one, this one did not.

### Screenshot

![image](https://github.com/user-attachments/assets/52935533-fe7f-47bd-a85d-7533474ab654)

Note: clicking a point on the "Total" curve performs as expected and shows the full history for that day.

### Issues Fixed or Closed

None.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
